### PR TITLE
Changes as per RFC001 and RFC002

### DIFF
--- a/Infrastructure-Scripts/Get-AzStorageAccountConnectionString.ps1
+++ b/Infrastructure-Scripts/Get-AzStorageAccountConnectionString.ps1
@@ -50,29 +50,29 @@ Param(
 
 try {
     # --- Check if the Resource Group exists in the subscription.
-    $resourceGroupExists = Get-AzResourceGroup $ResourceGroup
-    if (!$resourceGroupExists) {
+    $ResourceGroupExists = Get-AzResourceGroup $ResourceGroup
+    if (!$ResourceGroupExists) {
         throw "Resource Group $ResourceGroup does not exist."
     }
 
     # --- Check if Storage Account exists in the subscription.
-    $storageAccountExists = Get-AzStorageAccount -ResourceGroupName $ResourceGroup -Name $StorageAccount -ErrorAction SilentlyContinue
-    if (!$storageAccountExists) {
+    $StorageAccountExists = Get-AzStorageAccount -ResourceGroupName $ResourceGroup -Name $StorageAccount -ErrorAction SilentlyContinue
+    if (!$StorageAccountExists) {
         throw "Storage Account $StorageAccount does not exist."
     }
 
     # --- Return the respective Storage Account connection string.
     if ($UseSecondaryKey.IsPresent) {
-        $key = (Get-AzStorageAccountKey -ResourceGroupName $ResourceGroup -Name $StorageAccount)[1].Value
-        $connectionString = "DefaultEndpointsProtocol=https;AccountName=$($StorageAccount);AccountKey=$($key);EndpointSuffix=core.windows.net"
+        $Key = (Get-AzStorageAccountKey -ResourceGroupName $ResourceGroup -Name $StorageAccount)[1].Value
+        $ConnectionString = "DefaultEndpointsProtocol=https;AccountName=$($StorageAccount);AccountKey=$($Key);EndpointSuffix=core.windows.net"
     }
     else {
-        $key = (Get-AzStorageAccountKey -ResourceGroupName $ResourceGroup -Name $StorageAccount)[0].Value
-        $connectionString = "DefaultEndpointsProtocol=https;AccountName=$($StorageAccount);AccountKey=$($key);EndpointSuffix=core.windows.net"
+        $Key = (Get-AzStorageAccountKey -ResourceGroupName $ResourceGroup -Name $StorageAccount)[0].Value
+        $ConnectionString = "DefaultEndpointsProtocol=https;AccountName=$($StorageAccount);AccountKey=$($Key);EndpointSuffix=core.windows.net"
     }
 
     # --- Set the VSTS output variable using the returned connection string.
-    Write-Output ("##vso[task.setvariable variable=$($OutputVariable);issecret=true]$($connectionString)")
+    Write-Output ("##vso[task.setvariable variable=$($OutputVariable);issecret=true]$($ConnectionString)")
 }
 
 catch {

--- a/README.md
+++ b/README.md
@@ -41,15 +41,15 @@ Use the following as a checklist for creating new helper scripts.
 |Should| Contain comment based help.|     |
 |Should| Have external help markdown documentation.| Generated using PlatyPS. |
 |Should| Have a Pester unit test which passes all tests.| Save in Tests folder.     |
-|Should| Pester unit test filename to start UTxxx | Increment by one. |
+|Should| Pester unit test filename to start UTxxx. | Increment by one. |
 |Should| Use Az module cmdlets only.|     |
 |Should| Follow the naming covention. | See [Naming Conventions](#naming-conventions)    |
-|Should| Adhere to .editorconfig | Stored in .editorconfig |
-|Should| Adhere to .vscode settings | Stored in .vscode/settings.json|
-|Should| Use a forward slash in paths. | This is to ensure comptability on both Windows and Linux. |
+|Should| Adhere to .editorconfig. | Stored in .editorconfig |
+|Should| Adhere to .vscode settings. | Stored in .vscode/settings.json|
+|Should| Use a forward slash ('/') in paths. | This is to ensure compatibility on both Windows and Linux platforms. |
 | Should | Use -ErrorAction per cmdlet. |  |
 |Should NOT| Use aliases. |This can cause less readable code. |
-|Should NOT | Hard code credentials (especially plain text) | Expose sensitive information. |
+|Should NOT | Hard code credentials (especially plain text). | Expose sensitive information. |
 |Should NOT | Use Write-Host. | As explained by [Jeffrey Snover](http://www.jsnover.com/blog/2013/12/07/write-host-considered-harmful/) and [Don Jones](https://www.itprotoday.com/powershell/what-do-not-do-powershell-part-1) |
 |Should NOT | Set global error actions. | Using a global error action, particularly to suppress errors will hinder troubleshooting.  |
 
@@ -117,7 +117,7 @@ To ensure a consistant readable format, use the following naming conventions:
 | ------------------------------ | --------- | ------------ |
 | Global variables               | Pascal    | $Global:$Variable |
 | Parameter variables            | Pascal    | $ParameterVariable |
-| Local Variables                | camel    | $localVariable, $this, $args |
+| Local Variables                | Pascal    | $LocalVariable |
 | Language keywords              | lowercase    | foreach, -eq, try, catch, switch |
 | Process block keywords | lowercase | begin, process, end |
 | Keywords in comment-based help | UPPERCASE | .SYPNOSIS, .EXAMPLE |

--- a/Tests/Invoke-Tests.ps1
+++ b/Tests/Invoke-Tests.ps1
@@ -25,20 +25,20 @@ Param(
     [String] $TestType = "All"
 )
 
-$testParameters = @{
+$TestParameters = @{
     OutputFormat = 'NUnitXml'
     OutputFile   = "$PSScriptRoot\TEST-$TestType.xml"
     Script       = "$PSScriptRoot"
     PassThru     = $true
 }
 if ($TestType -ne 'All') {
-    $testParameters['Tag'] = $TestType
+    $TestParameters['Tag'] = $TestType
 }
 
 Remove-Item "$PSScriptRoot\TEST-*.xml"
 
-$result = Invoke-Pester @testParameters
+$Result = Invoke-Pester @TestParameters
 
-if ($result.FailedCount -ne 0) {
-    Write-Error "Pester returned $($result.FailedCount) errors"
+if ($Result.FailedCount -ne 0) {
+    Write-Error "Pester returned $($Result.FailedCount) errors"
 }

--- a/Tests/QT001.Quality.Tests.ps1
+++ b/Tests/QT001.Quality.Tests.ps1
@@ -1,29 +1,29 @@
-$scripts = Get-ChildItem -Path $PSScriptRoot/../Infrastructure-Scripts/*.ps1 -File
+$Scripts = Get-ChildItem -Path $PSScriptRoot/../Infrastructure-Scripts/*.ps1 -File
 
 Describe "Script documentation tests" -Tags @("Quality") {
 
-    foreach ($script in $scripts) {
+    foreach ($Script in $Scripts) {
 
-        $help = Get-Help $script.FullName
+        $Help = Get-Help $Script.FullName
 
-        Context $script.BaseName {
+        Context $Script.BaseName {
 
             It "Has a synopsis" {
-                $help.Synopsis | Should Not BeNullOrEmpty
+                $Help.Synopsis | Should Not BeNullOrEmpty
             }
 
             It "Has a description" {
-                $help.Description | Should Not BeNullOrEmpty
+                $Help.Description | Should Not BeNullOrEmpty
             }
 
             It "Has an example" {
-                $help.Examples | Should Not BeNullOrEmpty
+                $Help.Examples | Should Not BeNullOrEmpty
             }
 
-            foreach ($parameter in $help.Parameters.Parameter) {
-                if ($parameter -notmatch 'whatif|confirm') {
-                    It "Has a Parameter description for $($parameter.Name)" {
-                        $parameter.Description.Text | Should Not BeNullOrEmpty
+            foreach ($Parameter in $Help.Parameters.Parameter) {
+                if ($Parameter -notmatch 'whatif|confirm') {
+                    It "Has a Parameter description for $($Parameter.Name)" {
+                        $Parameter.Description.Text | Should Not BeNullOrEmpty
                     }
                 }
             }
@@ -33,19 +33,19 @@ Describe "Script documentation tests" -Tags @("Quality") {
 
 Describe "Script code quality tests" -Tags @("Quality") {
 
-    $rules = Get-ScriptAnalyzerRule
-    $excludeRules = @(
+    $Rules = Get-ScriptAnalyzerRule
+    $ExcludeRules = @(
         "PSAvoidUsingWriteHost",
         "PSAvoidUsingEmptyCatchBlock",
         "PSAvoidUsingPlainTextForPassword"
     )
 
-    foreach ($script in $scripts) {
-        Context $script.BaseName {
-            forEach ($rule in $rules) {
-                It "Should pass Script Analyzer rule $rule" {
-                    $result = Invoke-ScriptAnalyzer -Path $script.FullName -IncludeRule $rule -ExcludeRule $excludeRules
-                    $result.Count | Should Be 0
+    foreach ($Script in $Scripts) {
+        Context $Script.BaseName {
+            forEach ($Rule in $Rules) {
+                It "Should pass Script Analyzer rule $Rule" {
+                    $Result = Invoke-ScriptAnalyzer -Path $Script.FullName -IncludeRule $Rule -ExcludeRule $ExcludeRules
+                    $Result.Count | Should Be 0
                 }
             }
         }
@@ -54,12 +54,12 @@ Describe "Script code quality tests" -Tags @("Quality") {
 
 Describe "Should have a unit test file" -Tags @("Quality") {
 
-    foreach ($script in $scripts) {
-        $testName = "$($script.BaseName).Tests.ps1"
-        Context "$($script.BaseName)" {
-            It "Should have an associated unit test called UTxxx.$testName" {
-                $testFile = Get-Item -Path "$PSScriptRoot/UT*$testName" -ErrorAction SilentlyContinue
-                $testFile | Should Not Be $null
+    foreach ($Script in $Scripts) {
+        $TestName = "$($Script.BaseName).Tests.ps1"
+        Context "$($Script.BaseName)" {
+            It "Should have an associated unit test called UTxxx.$TestName" {
+                $TestFile = Get-Item -Path "$PSScriptRoot/UT*$TestName" -ErrorAction SilentlyContinue
+                $TestFile | Should Not Be $null
             }
         }
     }

--- a/Tests/UT001.Get-AzStorageAccountConnectionString.Tests.ps1
+++ b/Tests/UT001.Get-AzStorageAccountConnectionString.Tests.ps1
@@ -1,4 +1,4 @@
-$config = Get-Content $PSScriptRoot\..\Tests\Unit.Tests.Config.json -Raw | ConvertFrom-Json
+$Config = Get-Content $PSScriptRoot\..\Tests\Unit.Tests.Config.json -Raw | ConvertFrom-Json
 Set-Location $PSScriptRoot\..\Infrastructure-Scripts\
 
 Describe "Get-AzStorageAccountConnectionString Unit Tests" -Tags @("Unit") {
@@ -6,7 +6,7 @@ Describe "Get-AzStorageAccountConnectionString Unit Tests" -Tags @("Unit") {
     Context "Resource Group does not exist" {
         It "The specified Resource Group was not found in the subscription, throw an error" {
             Mock Get-AzResourceGroup -MockWith { Return $null }
-            { ./Get-AzStorageAccountConnectionString -ResourceGroup $config.resourceGroupName -StorageAccount $config.storageAccountName -OutputVariable $config.outputVariable } | Should throw "Resource Group $($config.resourceGroupName) does not exist."
+            { ./Get-AzStorageAccountConnectionString -ResourceGroup $Config.resourceGroupName -StorageAccount $Config.storageAccountName -OutputVariable $Config.outputVariable } | Should throw "Resource Group $($Config.resourceGroupName) does not exist."
             Assert-MockCalled -CommandName 'Get-AzResourceGroup' -Times 1 -Scope It
         }
     }
@@ -14,11 +14,11 @@ Describe "Get-AzStorageAccountConnectionString Unit Tests" -Tags @("Unit") {
     Context "Resource Group exists but not Storage Account" {
         It "The specified Storage Account was not found in the subscription, throw an error" {
             Mock Get-AzResourceGroup -MockWith {
-                $resourceGroupExist = [Microsoft.Azure.Management.ResourceManager.Models.ResourceGroup]::new($config.location, $null, $config.resourceGroupName)
-                return $resourceGroupExist
+                $ResourceGroupExist = [Microsoft.Azure.Management.ResourceManager.Models.ResourceGroup]::new($Config.location, $null, $Config.resourceGroupName)
+                return $ResourceGroupExist
             }
             Mock Get-AzStorageAccount -MockWith { Return $null }
-            { ./Get-AzStorageAccountConnectionString -ResourceGroup $config.resourceGroupName -StorageAccount $config.storageAccountName -OutputVariable $config.outputVariable } | Should throw "Storage Account $($config.storageAccountName) does not exist."
+            { ./Get-AzStorageAccountConnectionString -ResourceGroup $Config.resourceGroupName -StorageAccount $Config.storageAccountName -OutputVariable $Config.outputVariable } | Should throw "Storage Account $($Config.storageAccountName) does not exist."
             Assert-MockCalled -CommandName 'Get-AzResourceGroup' -Times 1 -Scope It
             Assert-MockCalled -CommandName 'Get-AzStorageAccount' -Times 1 -Scope It
         }
@@ -27,34 +27,34 @@ Describe "Get-AzStorageAccountConnectionString Unit Tests" -Tags @("Unit") {
     Context "Resource Group and Storage Account Exists, Return Storage Account Connection Strings" {
 
         Mock Get-AzResourceGroup -MockWith {
-            $resourceGroupExist = [Microsoft.Azure.Management.ResourceManager.Models.ResourceGroup]::new("West Europe", $null, $config.resourceGroupName)
-            return $resourceGroupExist
+            $ResourceGroupExist = [Microsoft.Azure.Management.ResourceManager.Models.ResourceGroup]::new("West Europe", $null, $Config.resourceGroupName)
+            return $ResourceGroupExist
         }
 
         Mock Get-AzStorageAccount -MockWith {
-            $storageAccountExist = [Microsoft.Azure.Management.Storage.Models.StorageAccount]::new("West Europe", $null, $config.storageAccountName)
-            return $storageAccountExist
+            $StorageAccountExist = [Microsoft.Azure.Management.Storage.Models.StorageAccount]::new("West Europe", $null, $Config.storageAccountName)
+            return $StorageAccountExist
         }
 
         Mock Get-AzStorageAccountKey -MockWith {
-            $keyArr = @()
+            $KeyArr = @()
             1..2 | ForEach-Object {
-                $keyArr += [Microsoft.Azure.Management.Storage.Models.StorageAccountKey]::new("Key$_", "Key$_", 1)
+                $KeyArr += [Microsoft.Azure.Management.Storage.Models.StorageAccountKey]::new("Key$_", "Key$_", 1)
             }
-            return $keyArr
+            return $KeyArr
         }
 
         It "Primary Storage Account Key is returned and environment output provided" {
-            $connectionString = ./Get-AzStorageAccountConnectionString -ResourceGroup $config.resourceGroupName -StorageAccount $config.storageAccountName -OutputVariable $config.outputVariable
-            $connectionString | Should Be "##vso[task.setvariable variable=$($config.outputVariable);issecret=true]DefaultEndpointsProtocol=https;AccountName=$($config.storageAccountName);AccountKey=key1;EndpointSuffix=core.windows.net"
+            $ConnectionString = ./Get-AzStorageAccountConnectionString -ResourceGroup $Config.resourceGroupName -StorageAccount $Config.storageAccountName -OutputVariable $Config.outputVariable
+            $ConnectionString | Should Be "##vso[task.setvariable variable=$($Config.outputVariable);issecret=true]DefaultEndpointsProtocol=https;AccountName=$($Config.storageAccountName);AccountKey=key1;EndpointSuffix=core.windows.net"
             Assert-MockCalled -CommandName 'Get-AzResourceGroup' -Times 1 -Scope It
             Assert-MockCalled -CommandName 'Get-AzStorageAccount' -Times 1 -Scope It
             Assert-MockCalled -CommandName 'Get-AzStorageAccountKey' -Times 1 -Scope It
         }
 
         It "Secondary Storage Account Key is returned and environment output provided" {
-            $connectionString = ./Get-AzStorageAccountConnectionString -ResourceGroup $config.resourceGroupName -StorageAccount $config.storageAccountName -OutputVariable $config.outputVariable -UseSecondaryKey
-            $connectionString | Should Be "##vso[task.setvariable variable=$($config.outputVariable);issecret=true]DefaultEndpointsProtocol=https;AccountName=$($config.storageAccountName);AccountKey=key2;EndpointSuffix=core.windows.net"
+            $ConnectionString = ./Get-AzStorageAccountConnectionString -ResourceGroup $Config.resourceGroupName -StorageAccount $Config.storageAccountName -OutputVariable $Config.outputVariable -UseSecondaryKey
+            $ConnectionString | Should Be "##vso[task.setvariable variable=$($Config.outputVariable);issecret=true]DefaultEndpointsProtocol=https;AccountName=$($Config.storageAccountName);AccountKey=key2;EndpointSuffix=core.windows.net"
             Assert-MockCalled -CommandName 'Get-AzResourceGroup' -Times 1 -Scope It
             Assert-MockCalled -CommandName 'Get-AzStorageAccount' -Times 1 -Scope It
             Assert-MockCalled -CommandName 'Get-AzStorageAccountKey' -Times 1 -Scope It


### PR DESCRIPTION
- As per RFC001, I have changed all local variables to use PascalCase. I have also updated the naming convention table in README.md.

- As per RFC002, I have ensured that the README.md Helper Script Checklist table has a Should requirement for using forward slashes for platform compatibility.