### PR TITLE
Set-ArmTemplateOutputVariables.ps1 Script Addition +semver: minor

### DIFF
--- a/Infrastructure-Scripts/Set-ArmTemplateOutputVariables.ps1
+++ b/Infrastructure-Scripts/Set-ArmTemplateOutputVariables.ps1
@@ -3,8 +3,8 @@
     Takes ARM template output(s) and converts into Azure DevOps variables.
 
     .DESCRIPTION
-    Takes ARM template output(s), usually from the  Azure resource group deployment task in Azure DevOps,
-    and creates Azure DevOps variables of the same output name so that the values can be used in subsequent pipeline tasks.
+    Takes ARM template output(s), usually from the Azure resource group deployment task in Azure DevOps.
+    Creates Azure DevOps variables of the same output name so that the values can be used in subsequent pipeline tasks.
 
     .PARAMETER ArmOutput
     The JSON output from the ARM template to convert into variables.

--- a/Infrastructure-Scripts/Set-ArmTemplateOutputVariables.ps1
+++ b/Infrastructure-Scripts/Set-ArmTemplateOutputVariables.ps1
@@ -1,0 +1,54 @@
+<#
+    .SYNOPSIS
+    Takes ARM template output(s) and converts into Azure DevOps variables.
+
+    .DESCRIPTION
+    Takes ARM template output(s), usually from the  Azure resource group deployment task in Azure DevOps,
+    and creates Azure DevOps variables of the same output name so that the values can be used in subsequent pipeline tasks.
+
+    .PARAMETER ArmOutput
+    The JSON output from the ARM template to convert into variables.
+    If using the  Azure resource group deployment task in an Azure Pipeline, you can set the output to a variable by specifying `Outputs > Deployment outputs`.
+
+    .EXAMPLE
+    Set-ArmTemplateOutputVariables.ps1 -ArmOutput '$(ArmOutputs)'
+    where ArmOutputs is the name from Outputs > Deployment outputs from the  Azure resource group deployment task
+#>
+
+[CmdletBinding()]
+Param(
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [String]$ArmOutput
+)
+
+try {
+
+    # --- Convert the ArmOutput JSON
+    try {
+        $Outputs = $ArmOutput | ConvertFrom-Json
+    }
+    catch {
+        throw "There was an error, is the 'Deployment output' set in the 'Azure resource group deployment' task?"
+    }
+
+    # --- The outputs will be of type noteproperty, get a list of all of them
+    foreach ($OutputName in ($Outputs | Get-Member -MemberType NoteProperty).name) {
+
+        # --- Get the type and value for each output
+        $OutTypeValue = $Outputs | Select-Object -ExpandProperty $OutputName
+        $OutValue = $OutTypeValue.value
+
+        # --- Set Azure DevOps variable(s)
+        Write-Output "Setting $OutputName"
+        Write-Output "##vso[task.setvariable variable=$OutputName;issecret=true]$OutValue"
+
+    }
+
+    return "Outputs set as pipeline variables successfully."
+
+}
+
+catch {
+    throw "$_"
+}

--- a/Tests/UT003.Set-ArmTemplateOutputVariables.Tests.ps1
+++ b/Tests/UT003.Set-ArmTemplateOutputVariables.Tests.ps1
@@ -1,0 +1,26 @@
+Set-Location $PSScriptRoot\..\infrastructure-scripts\
+
+Describe "Set-ArmTemplateOutputVariables.ps1 Unit Tests" -Tags @("Unit") {
+
+    Context "The parameter 'ArmOutput' is null or empty" {
+        It "Should throw an error" {
+            $ArmOutput = $null
+            { .\Set-ArmTemplateOutputVariables.ps1 -ArmOutput $ArmOutput } | Should Throw
+        }
+    }
+
+    Context "The parameter 'ArmOutput' JSON input is invalid" {
+        It "Should throw an error" {
+            $ArmOutput = '{"testOutput":{"type":"String","value":"testOutputValue"}'
+            { .\Set-ArmTemplateOutputVariables.ps1 -ArmOutput $ArmOutput } | Should Throw
+        }
+    }
+
+    Context "The parameter 'ArmOutput' input was valid" {
+        It "Should set variables" {
+            $ArmOutput = '{"testOutput":{"type":"String","value":"testOutputValue"}}'
+            .\Set-ArmTemplateOutputVariables.ps1 -ArmOutput $ArmOutput | Should Contain "Outputs set as pipeline variables successfully."
+        }
+    }
+
+}

--- a/Tests/UT003.Set-ArmTemplateOutputVariables.Tests.ps1
+++ b/Tests/UT003.Set-ArmTemplateOutputVariables.Tests.ps1
@@ -16,7 +16,7 @@ Describe "Set-ArmTemplateOutputVariables.ps1 Unit Tests" -Tags @("Unit") {
         }
     }
 
-    Context "The parameter 'ArmOutput' input was valid" {
+    Context "The parameter 'ArmOutput' JSON input in valid" {
         It "Should set variables" {
             $ArmOutput = '{"testOutput":{"type":"String","value":"testOutputValue"}}'
             .\Set-ArmTemplateOutputVariables.ps1 -ArmOutput $ArmOutput | Should Contain "Outputs set as pipeline variables successfully."

--- a/Tests/UT003.Set-ArmTemplateOutputVariables.Tests.ps1
+++ b/Tests/UT003.Set-ArmTemplateOutputVariables.Tests.ps1
@@ -1,4 +1,4 @@
-Set-Location $PSScriptRoot\..\infrastructure-scripts\
+Set-Location $PSScriptRoot\..\Infrastructure-Scripts\
 
 Describe "Set-ArmTemplateOutputVariables.ps1 Unit Tests" -Tags @("Unit") {
 


### PR DESCRIPTION
This PR is to add a new infrastructure script and associated Pester unit test script:

- Set-ArmTemplateOutputVariables.ps1
- UT003.Set-ArmTemplateOutputVariables.Tests.ps1

The new script takes ARM template output(s), usually from the Azure resource group deployment task in Azure DevOps and creates Azure DevOps variables of the same output name so that the values can be used in subsequent pipeline tasks.