### PR TITLE
Adding new script Set-AzResourceGroupTags.ps1 +semver: minor

### DIFF
--- a/Infrastructure-Scripts/Set-AzResourceGroupTags.ps1
+++ b/Infrastructure-Scripts/Set-AzResourceGroupTags.ps1
@@ -52,65 +52,52 @@ try {
     $ResourceGroup = Get-AzResourceGroup -Name $ResourceGroupName -ErrorAction SilentlyContinue
 
     if (!$ResourceGroup) {
-
         Write-Verbose -Message "Resource group $ResourceGroupName doesn't exist, creating resource group"
         New-AzResourceGroup -Name $ResourceGroupName -Location $Location -Tag $Tags
-
     }
 
     else {
-
         Write-Verbose -Message "Resource group $ResourceGroupName exists, validating tags"
         $UpdateTags = $false
 
         if ($ResourceGroup.Tags) {
-
             # --- Check existing tags and update if necessary
             $UpdatedTags = $ResourceGroup.Tags
             foreach ($Key in $Tags.Keys) {
-
                 Write-Verbose "Current value of Resource Group Tag $Key is $($ResourceGroup.Tags[$Key])"
 
                 if ($($ResourceGroup.Tags[$Key]) -eq $($Tags[$Key])) {
-
                     Write-Verbose -Message "Current value of tag ($($ResourceGroup.Tags[$Key])) matches parameter ($($Tags[$Key]))"
-
                 }
 
                 elseif ($null -eq $($ResourceGroup.Tags[$Key])) {
-
                     Write-Verbose -Message ("Tag value is not set, adding tag {0} with value {1}" -f $Key, $Tags[$Key])
                     $UpdatedTags[$Key] = $Tags[$Key]
                     $UpdateTags = $true
-
                 }
 
                 else {
-
                     Write-Verbose -Message ("Tag value is incorrect, setting tag {0} with value {1}" -f $Key, $Tags[$Key])
                     $UpdatedTags[$Key] = $Tags[$Key]
                     $UpdateTags = $true
-
                 }
+
             }
 
         }
 
         else {
-
             # --- No tags to check, just update with the passed in tags
             $UpdatedTags = $Tags
             $UpdateTags = $true
-
         }
 
         if ($UpdateTags) {
-
             Write-Verbose -Message "Replacing existing tags:"
             $UpdatedTags
             Set-AzResourceGroup -Name $ResourceGroup.ResourceGroupName -Tag $UpdatedTags
-
         }
+
     }
 
 }

--- a/Infrastructure-Scripts/Set-AzResourceGroupTags.ps1
+++ b/Infrastructure-Scripts/Set-AzResourceGroupTags.ps1
@@ -1,0 +1,120 @@
+<#
+    .SYNOPSIS
+    Sets standard tags on a Resource Group required by the ESFA.
+
+    .DESCRIPTION
+    Checks if a Resource Group exists, if it doesn't, create with specified tags.  If it does exist, validates that the tags are match those specified in the parameters and updates them if necessary.
+    Removed ValidateSet for ParentBusiness and ServiceOffering so it's more generic and there are loads for AS.
+
+    .PARAMETER ResourceGroupName
+    Name of the Resource Group to be created and/or have tags applied.
+
+    .PARAMETER Location
+    [Optional]Location of the Resource Group, defaults to West Europe.
+
+    .PARAMETER Environment
+    Name of the environment, select from a valid ESFA environment name tag: Production, Pre-Production or Dev/Test.
+
+    .PARAMETER ParentBusiness
+    Name of the business to which the resources belong, e.g. Apprenticeships, Apprenticeships (PP).
+
+    .PARAMETER ServiceOffering
+    Name of the service offering to which the resources belong, e.g. AS Commitments, AS Commitments (PP).
+
+    .EXAMPLE
+    Set-ResourceGroupTags -ResourceGroupName "das-at-foobar-rg" -Environment "Dev/Test" -ParentBusiness "Apprenticeships" -ServiceOffering "AS Commitments"
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$ResourceGroupName,
+    [Parameter(Mandatory = $false)]
+    [string]$Location = "West Europe",
+    [Parameter(Mandatory = $true)]
+    [ValidateSet("Production", "Pre-Production", "Dev/Test")]
+    [string]$Environment,
+    [Parameter(Mandatory = $true)]
+    [string]$ParentBusiness,
+    [Parameter(Mandatory = $true)]
+    [string]$ServiceOffering
+)
+
+try {
+
+    $Tags = @{
+        Environment        = $Environment
+        'Parent Business'  = $ParentBusiness
+        'Service Offering' = $ServiceOffering
+    }
+
+    Write-Verbose -Message "Attempting to retrieve existing resource group $ResourceGroupName"
+    $ResourceGroup = Get-AzResourceGroup -Name $ResourceGroupName -ErrorAction SilentlyContinue
+
+    if (!$ResourceGroup) {
+
+        Write-Verbose -Message "Resource group $ResourceGroupName doesn't exist, creating resource group"
+        New-AzResourceGroup -Name $ResourceGroupName -Location $Location -Tag $Tags
+
+    }
+
+    else {
+
+        Write-Verbose -Message "Resource group $ResourceGroupName exists, validating tags"
+        $UpdateTags = $false
+
+        if ($ResourceGroup.Tags) {
+
+            # --- Check existing tags and update if necessary
+            $UpdatedTags = $ResourceGroup.Tags
+            foreach ($Key in $Tags.Keys) {
+
+                Write-Verbose "Current value of Resource Group Tag $Key is $($ResourceGroup.Tags[$Key])"
+
+                if ($($ResourceGroup.Tags[$Key]) -eq $($Tags[$Key])) {
+
+                    Write-Verbose -Message "Current value of tag ($($ResourceGroup.Tags[$Key])) matches parameter ($($Tags[$Key]))"
+
+                }
+
+                elseif ($null -eq $($ResourceGroup.Tags[$Key])) {
+
+                    Write-Verbose -Message ("Tag value is not set, adding tag {0} with value {1}" -f $Key, $Tags[$Key])
+                    $UpdatedTags[$Key] = $Tags[$Key]
+                    $UpdateTags = $true
+
+                }
+
+                else {
+
+                    Write-Verbose -Message ("Tag value is incorrect, setting tag {0} with value {1}" -f $Key, $Tags[$Key])
+                    $UpdatedTags[$Key] = $Tags[$Key]
+                    $UpdateTags = $true
+
+                }
+            }
+
+        }
+
+        else {
+
+            # --- No tags to check, just update with the passed in tags
+            $UpdatedTags = $Tags
+            $UpdateTags = $true
+
+        }
+
+        if ($UpdateTags) {
+
+            Write-Verbose -Message "Replacing existing tags:"
+            $UpdatedTags
+            Set-AzResourceGroup -Name $ResourceGroup.ResourceGroupName -Tag $UpdatedTags
+
+        }
+    }
+
+}
+
+catch {
+    throw "$_"
+}

--- a/Tests/UT.Set-AzResourceGroupTags.Tests.ps1
+++ b/Tests/UT.Set-AzResourceGroupTags.Tests.ps1
@@ -7,12 +7,14 @@ Describe "Set-AzResourceGroupTags.ps1 Unit Tests" -Tags @("Unit") {
         It "Should create a new Resource Group with 3 tags" {
             Mock Get-AzResourceGroup -MockWith { Return $null }
             Mock New-AzResourceGroup -MockWith {
-                $Tags = New-Object 'system.collections.generic.dictionary[string,string]'
-                $Tags.Add("Environment", $Config.environment)
-                $Tags.Add("Parent Business", $Config.parentBusinessTag)
-                $Tags.Add("Service Offering", $Config.serviceOffering)
-                $ResourceGroup = [Microsoft.Azure.Management.ResourceManager.Models.ResourceGroup]::new($Config.location, $null, $Config.resourceGroupName, $null, $null, $Tags)
-                return $ResourceGroup
+                return @{
+                    "ResourceGroupName" = $Config.resourceGroupName
+                    "Tags"              = @{
+                        Environment        = $Config.environment
+                        'Parent Business'  = $Config.parentBusinessTag
+                        'Service Offering' = $Config.serviceOffering
+                    }
+                }
             }
             $Result = ./Set-AzResourceGroupTags -ResourceGroupName $Config.resourceGroupName -Environment $Config.environment -ParentBusiness $Config.parentBusinessTag -ServiceOffering $Config.serviceOffering
             $Result.Tags.Count | Should Be 3

--- a/Tests/UT.Set-AzResourceGroupTags.Tests.ps1
+++ b/Tests/UT.Set-AzResourceGroupTags.Tests.ps1
@@ -1,0 +1,43 @@
+$Config = Get-Content $PSScriptRoot\..\Tests\Unit.Tests.Config.json -Raw | ConvertFrom-Json
+Set-Location $PSScriptRoot\..\Infrastructure-Scripts\
+
+Describe "Set-AzResourceGroupTags.ps1 Unit Tests" -Tags @("Unit") {
+
+    Context "Resource Group does not exist" {
+        It "Should create a new Resource Group with 3 tags" {
+            Mock Get-AzResourceGroup -MockWith { Return $null }
+            Mock New-AzResourceGroup -MockWith {
+                $Tags = New-Object 'system.collections.generic.dictionary[string,string]'
+                $Tags.Add("Environment", $Config.environment)
+                $Tags.Add("Parent Business", $Config.parentBusinessTag)
+                $Tags.Add("Service Offering", $Config.serviceOffering)
+                $ResourceGroup = [Microsoft.Azure.Management.ResourceManager.Models.ResourceGroup]::new($Config.location, $null, $Config.resourceGroupName, $null, $null, $Tags)
+                return $ResourceGroup
+            }
+            $Result = ./Set-AzResourceGroupTags -ResourceGroupName $Config.resourceGroupName -Environment $Config.environment -ParentBusiness $Config.parentBusinessTag -ServiceOffering $Config.serviceOffering
+            $Result.Tags.Count | Should Be 3
+            Assert-MockCalled -CommandName 'Get-AzResourceGroup' -Times 1 -Scope It
+            Assert-MockCalled -CommandName 'New-AzResourceGroup' -Times 1 -Scope It
+        }
+    }
+
+    Context "Resource Group exists" {
+        It "Should add or update an existing Resource Groups set of tags" {
+            Mock Get-AzResourceGroup -MockWith {
+                return @{
+                    "ResourceGroupName" = $Config.resourceGroupName
+                }
+            }
+            Mock Set-AzResourceGroup -MockWith {
+                return @{
+                    "ResourceGroupName" = $Config.resourceGroupName
+                }
+            }
+            { ./Set-AzResourceGroupTags -ResourceGroupName $Config.resourceGroupName -Environment $Config.environment -ParentBusiness $Config.parentBusinessTag -ServiceOffering $Config.serviceOffering } | Should Not Throw
+            Assert-MockCalled -CommandName 'Get-AzResourceGroup' -Times 1 -Scope It
+            Assert-MockCalled -CommandName 'Set-AzResourceGroup' -Times 1 -Scope It
+        }
+
+    }
+
+}

--- a/Tests/Unit.Tests.Config.json
+++ b/Tests/Unit.Tests.Config.json
@@ -3,6 +3,9 @@
   "resourceGroupName": "das-test-pester-rg",
   "storageAccountName": "dastestpestersa",
   "outputVariable": "StorageConnectionString",
+  "environment": "Dev/Test",
+  "parentBusinessTag": "Apprenticeships",
+  "serviceOffering": "AS Manage your apprenticeships",
   "statuscakeTestName": "MyStatuscakeTest",
   "statuscakeTestUrl": "https://www.testurl.com/"
 }


### PR DESCRIPTION
- Adding new script `Infrastructure-Scripts/Set-AzResourceGroupTags.ps1`. This is an updated version of the Set-ResourceGroupTags.ps1 script using the Az module cmdlets and the das-platform-automation requirements.
- Adding an associated Pester unit test `Tests/UT.Set-AzResourceGroupTags.Tests.ps1`
- Updated `Tests/Unit.Tests.Config.ps1` with config variables required by `Tests/UT.Set-AzResourceGroupTags.Tests.ps1`