### PR TITLE
Add New Script   New-ServiceBusConnectionString.ps1 +semver: minor 

### DIFF
--- a/Infrastructure-Scripts/New-ServiceBusConnectionString.ps1
+++ b/Infrastructure-Scripts/New-ServiceBusConnectionString.ps1
@@ -1,0 +1,73 @@
+<#
+.SYNOPSIS
+Get a connection string for a servicebus namespace
+.DESCRIPTION
+Get a connection string for a servicebus namespace. If one does not exist with the given name, it will be created
+.PARAMETER ResourceGroupName
+The name of the destination Resource Group for the resource
+.PARAMETER NamespaceName
+The name of the Service Bus Namespace
+.PARAMETER AuthorizationRuleName
+The name of the authorization rule to be created
+.PARAMETER Rights
+A list of rights. This can be one or all of the following:
+Listen
+Send
+Manage
+.PARAMETER ConnectionStringType
+The connection string to return. This can be either Primary or Secondary.
+.EXAMPLE
+.\New-ServiceBusConnectionString.ps1 -NamespaceName test-namespace -AuthorizationRuleName auth1 -Rights Listen, Send, Manage -ConnectionStringType Secondary
+#>
+
+[CmdletBinding()]
+Param (
+    [Parameter(Mandatory = $true)]
+    [String]$NamespaceName,
+    [Parameter(Mandatory = $true)]
+    [String]$AuthorizationRuleName,
+    [Parameter(Mandatory = $true)]
+    [ValidateSet("Listen", "Send", "Manage")]
+    [String[]]$Rights,
+    [Parameter(Mandatory = $false)]
+    [ValidateSet("Primary", "Secondary")]
+    [String[]]$ConnectionStringType = "Primary"
+)
+
+try {
+
+
+    $ServiceBusResource = Get-AzResource -Name $NamespaceName
+    if (!$ServiceBusResource) {
+        throw "Could not find servicebus namespace $NamespaceName"
+    }
+
+    $AuthorizationRule = Get-AzServiceBusAuthorizationRule -ResourceGroupName $ServiceBusResource.ResourceGroupName -Namespace $NameSpaceName -Name $AuthorizationRuleName -ErrorAction SilentlyContinue
+    if (!$AuthorizationRule) {
+        $AuthorizationRuleParameters = @{
+            ResourceGroupName = $ServiceBusResource.ResourceGroupName
+            Namespace         = $NamespaceName
+            Name              = $AuthorizationRuleName
+            Rights            = $Rights
+        }
+        $null = New-AzServiceBusAuthorizationRule @AuthorizationRuleParameters
+    }
+
+    $ServiceBusKey = Get-AzServiceBusKey -ResourceGroupName $ServiceBusResource.ResourceGroupName -Namespace $NamespaceName -Name $AuthorizationRuleName
+
+    switch ($ConnectionStringType) {
+        'Primary' {
+            $ConnectionString = $ServiceBusKey.PrimaryConnectionString
+            break
+        }
+        'Secondary' {
+            $ConnectionString = $ServiceBusKey.SecondaryConnectionString
+            break
+        }
+    }
+    Write-Output ("##vso[task.setvariable variable=ServiceBusConnectionString; issecret=true]$($ConnectionString)")
+
+}
+catch {
+    throw $_
+}

--- a/Infrastructure-Scripts/New-ServiceBusConnectionString.ps1
+++ b/Infrastructure-Scripts/New-ServiceBusConnectionString.ps1
@@ -1,23 +1,29 @@
 <#
-.SYNOPSIS
-Get a connection string for a servicebus namespace
-.DESCRIPTION
-Get a connection string for a servicebus namespace. If one does not exist with the given name, it will be created
-.PARAMETER ResourceGroupName
-The name of the destination Resource Group for the resource
-.PARAMETER NamespaceName
-The name of the Service Bus Namespace
-.PARAMETER AuthorizationRuleName
-The name of the authorization rule to be created
-.PARAMETER Rights
-A list of rights. This can be one or all of the following:
-Listen
-Send
-Manage
-.PARAMETER ConnectionStringType
-The connection string to return. This can be either Primary or Secondary.
-.EXAMPLE
-.\New-ServiceBusConnectionString.ps1 -NamespaceName test-namespace -AuthorizationRuleName auth1 -Rights Listen, Send, Manage -ConnectionStringType Secondary
+    .SYNOPSIS
+    Get a Connection String for a Service Bus namespace.
+
+    .DESCRIPTION
+    Get a Connection String for a Service Bus namespace. If one does not exist with the given name, it will be created.
+
+    .PARAMETER NamespaceName
+    The name of the Service Bus namespace.
+
+    .PARAMETER AuthorizationRuleName
+    The name of the authorization rule to be created.
+
+    .PARAMETER Rights
+    A list of authorization rule rights. This can be one or all of the following:
+    Listen
+    Send
+    Manage
+
+    .PARAMETER ConnectionStringType
+    The Connection String to return. This can be either be Primary or Secondary.
+
+    .EXAMPLE
+    .\New-ServiceBusConnectionString.ps1 -NamespaceName test-namespace -AuthorizationRuleName auth1 -Rights Listen, Send, Manage -ConnectionStringType Secondary
+
+    Return the Secondary Connection String for the specified authorization rule, if the authorization rule does not exist it will be created.
 #>
 
 [CmdletBinding()]
@@ -36,10 +42,9 @@ Param (
 
 try {
 
-
     $ServiceBusResource = Get-AzResource -Name $NamespaceName
     if (!$ServiceBusResource) {
-        throw "Could not find servicebus namespace $NamespaceName"
+        throw "Could not find Service Bus namespace $NamespaceName"
     }
 
     $AuthorizationRule = Get-AzServiceBusAuthorizationRule -ResourceGroupName $ServiceBusResource.ResourceGroupName -Namespace $NameSpaceName -Name $AuthorizationRuleName -ErrorAction SilentlyContinue
@@ -54,7 +59,6 @@ try {
     }
 
     $ServiceBusKey = Get-AzServiceBusKey -ResourceGroupName $ServiceBusResource.ResourceGroupName -Namespace $NamespaceName -Name $AuthorizationRuleName
-
     switch ($ConnectionStringType) {
         'Primary' {
             $ConnectionString = $ServiceBusKey.PrimaryConnectionString
@@ -65,9 +69,11 @@ try {
             break
         }
     }
+
     Write-Output ("##vso[task.setvariable variable=ServiceBusConnectionString; issecret=true]$($ConnectionString)")
 
 }
+
 catch {
     throw $_
 }

--- a/Tests/UT.New-ServiceBusConnectionString.Tests.ps1
+++ b/Tests/UT.New-ServiceBusConnectionString.Tests.ps1
@@ -13,7 +13,6 @@ Describe "New-ServiceBusConnectionStrings Unit Tests" -Tags @("Unit") {
     Context "Namespace and Authorisation rules exists, Return Authorisation rules Connection Strings" {
 
 
-
         Mock Get-AzResource -MockWith {
             return @{
                 "Name" = $Config.NamespaceName

--- a/Tests/UT.New-ServiceBusConnectionString.Tests.ps1
+++ b/Tests/UT.New-ServiceBusConnectionString.Tests.ps1
@@ -1,0 +1,108 @@
+$Config = Get-Content $PSScriptRoot\..\Tests\Unit.Tests.Config.json -Raw | ConvertFrom-Json
+Set-Location $PSScriptRoot\..\Infrastructure-Scripts\
+
+Describe "New-ServiceBusConnectionStrings Unit Tests" -Tags @("Unit") {
+
+    Context "Service Bus Namespace does not exist" {
+        It "The specified Service Bus Namespace  was not found in the subscription, throw an error" {
+            Mock Get-AzResource -MockWith { Return $null }
+            { ./New-ServiceBusConnectionString -NamespaceName $Config.NamespaceName -AuthorizationRuleName $Config.AuthorizationRuleName -Rights $Config.Rights } | Should throw "Could not find servicebus namespace $($Config.NamespaceName)"
+            Assert-MockCalled -CommandName 'Get-AzResource' -Times 1 -Scope It
+        }
+    }
+    Context "Namespace and Authorisation rules exists, Return Authorisation rules Connection Strings" {
+
+
+
+        Mock Get-AzResource -MockWith {
+            return @{
+                "Name" = $Config.NamespaceName
+                "ResourceGroupName"= $Config.ResourceGroupName
+                "ResourceType" = " Microsoft.ServiceBus/namespaces"
+                "Location" = "westeurope"
+                "ResourceId" = "aRsourceID"
+            }
+        }
+
+        Mock Get-AzServiceBusAuthorizationRule -MockWith {
+            return @{
+                "Id" = "anId"
+                "Name" = $Config.AuthorizationRuleName
+                "Rights" = $Config.Rights
+            }
+
+        }
+
+        Mock Get-AzServiceBusKey -MockWith {
+            $ServiceBusKey =[Microsoft.Azure.Commands.ServiceBus.Models.PSListKeysAttributes]::new($null)
+            return $ServiceBusKey
+
+        }
+
+        It "Primary Storage Account Key is returned and environment output provided" {
+            $ConnectionString = ./New-ServiceBusConnectionString -NamespaceName $Config.NamespaceName -AuthorizationRuleName $Config.AuthorizationRuleName -Rights $Config.Rights
+            $ConnectionString | Should BeLike '*task.setvariable*'
+            Assert-MockCalled -CommandName 'Get-AzResource' -Times 1 -Scope It
+            Assert-MockCalled -CommandName 'Get-AzServiceBusAuthorizationRule' -Times 1 -Scope It
+            Assert-MockCalled -CommandName 'Get-AzServiceBusKey' -Times 1 -Scope It
+        }
+
+        It "Secondary Storage Account Key is returned and environment output provided" {
+            $ConnectionString = ./New-ServiceBusConnectionString -NamespaceName $Config.NamespaceName -AuthorizationRuleName $Config.AuthorizationRuleName -Rights $Config.Rights -ConnectionStringType "Secondary"
+            $ConnectionString | Should BeLike '*task.setvariable*'
+            Assert-MockCalled -CommandName 'Get-AzResource' -Times 1 -Scope It
+            Assert-MockCalled -CommandName 'Get-AzServiceBusAuthorizationRule' -Times 1 -Scope It
+            Assert-MockCalled -CommandName 'Get-AzServiceBusKey' -Times 1 -Scope It
+        }
+
+    }
+
+    Context "Namespace exists but Authorisation rules do not exists,Create new Rule and Return Authorisation rules Connection Strings" {
+
+
+
+        Mock Get-AzResource -MockWith {
+            return @{
+                "Name" = $Config.NamespaceName
+                "ResourceGroupName"= $Config.ResourceGroupName
+                "ResourceType" = " Microsoft.ServiceBus/namespaces"
+                "Location" = "westeurope"
+                "ResourceId" = "aRsourceID"
+            }
+        }
+
+        Mock Get-AzServiceBusAuthorizationRule -MockWith {
+            return $null
+
+        }
+
+        Mock Get-AzServiceBusKey -MockWith {
+            $ServiceBusKey =[Microsoft.Azure.Commands.ServiceBus.Models.PSListKeysAttributes]::new($null)
+            return $ServiceBusKey
+
+        }
+
+        Mock New-AzServiceBusAuthorizationRule -MockWith {
+            return $null
+        }
+
+        It "Primary Storage Account Key is returned and environment output provided" {
+            $ConnectionString = ./New-ServiceBusConnectionString -NamespaceName $Config.NamespaceName -AuthorizationRuleName $Config.AuthorizationRuleName -Rights $Config.Rights
+            $ConnectionString | Should BeLike '*task.setvariable*'
+            Assert-MockCalled -CommandName 'Get-AzResource' -Times 1 -Scope It
+            Assert-MockCalled -CommandName 'Get-AzServiceBusAuthorizationRule' -Times 1 -Scope It
+            Assert-MockCalled -CommandName 'New-AzServiceBusAuthorizationRule' -Times 1
+            Assert-MockCalled -CommandName 'Get-AzServiceBusKey' -Times 1 -Scope It
+        }
+
+        It "Secondary Storage Account Key is returned and environment output provided" {
+            $ConnectionString = ./New-ServiceBusConnectionString -NamespaceName $Config.NamespaceName -AuthorizationRuleName $Config.AuthorizationRuleName -Rights $Config.Rights -ConnectionStringType "Secondary"
+            $ConnectionString | Should BeLike '*task.setvariable*'
+            Assert-MockCalled -CommandName 'Get-AzResource' -Times 1 -Scope It
+            Assert-MockCalled -CommandName 'Get-AzServiceBusAuthorizationRule' -Times 1 -Scope It
+            Assert-MockCalled -CommandName 'New-AzServiceBusAuthorizationRule' -Times 1
+            Assert-MockCalled -CommandName 'Get-AzServiceBusKey' -Times 1 -Scope It
+        }
+
+    }
+}

--- a/Tests/Unit.Tests.Config.json
+++ b/Tests/Unit.Tests.Config.json
@@ -8,5 +8,8 @@
   "serviceOffering": "AS Manage your apprenticeships",
   "statuscakeTestName": "MyStatuscakeTest",
   "statuscakeTestUrl": "https://www.testurl.com/",
-  "receptacleName": "areceptacle"
+  "receptacleName": "areceptacle",
+  "NamespaceName": "ANameSpace",
+  "AuthorizationRuleName": "AnAuthorizationRule",
+  "Rights": "Send"
 }

--- a/Tests/Unit.Tests.Config.json
+++ b/Tests/Unit.Tests.Config.json
@@ -8,8 +8,8 @@
   "serviceOffering": "AS Manage your apprenticeships",
   "statuscakeTestName": "MyStatuscakeTest",
   "statuscakeTestUrl": "https://www.testurl.com/",
-  "receptacleName": "areceptacle",
-  "NamespaceName": "ANameSpace",
+  "receptacleName": "AReceptacle",
+  "NamespaceName": "ANamespace",
   "AuthorizationRuleName": "AnAuthorizationRule",
   "Rights": "Send"
 }


### PR DESCRIPTION
Added Script New-ServiceBusConnectionString.ps1 Which returns either the primary or the secondary connection strings for a specific authorisation within a service bus namespace creating the authorisation if required and using this to update a variable ServiceBusConnectionString.

Created unit tests for the above script.

updated the Test config with appropriate values