### PR TITLE
New Set-AzResourceTags Script +semver: minor

### DIFF
--- a/Infrastructure-Scripts/Set-AzResourceTags.ps1
+++ b/Infrastructure-Scripts/Set-AzResourceTags.ps1
@@ -1,0 +1,75 @@
+<#
+    .SYNOPSIS
+    Sets standard tags on Resources in a Resource Group to match those on the Resource Group.
+
+    .DESCRIPTION
+    Checks if a Resource Group exists,  If it does exist, creates or updates the Standard Tags on any Resource in the Resource Group to match those of the
+    parent Resource group without removing any additions
+
+    .PARAMETER ResourceGroupName
+    Name of the Resource Group to be created and/or have tags applied.
+
+
+    .EXAMPLE
+    Set-ResourceTags -ResourceGroupName "das-at-foobar-rg"
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$ResourceGroupName
+)
+
+try {
+    $Group = Get-AzResourceGroup -ResourceGroupName $ResourceGroupName
+    if ($null -ne $Group.Tags) {
+        $Resources = Get-AzResource -ResourceGroupName $Group.ResourceGroupName
+        foreach ($R in $Resources) {
+            $TagChanges = $false
+            $ResourceTags = (Get-AzResource -ResourceId $R.ResourceId).Tags
+            if ($ResourceTags) {
+                foreach ($Key in $Group.Tags.Keys) {
+                    if (-not($ResourceTags.ContainsKey($Key))) {
+                        Write-Output "ADD: $($R.Name) - $Key"
+                        $ResourceTags.Add($Key, $Group.Tags[$Key])
+                        $TagChanges = $true
+                    }
+                    else {
+                        if ($ResourceTags[$Key] -eq $Group.Tags[$Key]) {
+                            # Key is up-to-date
+                        }
+                        else {
+                            Write-Output "UPD: $($R.Name) - $Key"
+                            $null = $ResourceTags.Remove($Key)
+                            $ResourceTags.Add($Key, $Group.Tags[$Key])
+                            $TagChanges = $true
+                        }
+                    }
+                }
+                $TagsToWrite = $ResourceTags
+            }
+            else {
+                # All tags missing
+                Write-Output "ADD: $($R.Name) - All tags from RG"
+                $TagsToWrite = $Group.Tags
+                $TagChanges = $true
+            }
+            if ($TagChanges) {
+                try {
+                    $Result = Set-AzResource -Tag $TagsToWrite -ResourceId $R.ResourceId -Force -ErrorAction Stop
+                    Write-Output $Result
+                }
+                catch {
+                    # Write-Error "$($R.Name) - $($Group.ResourceID) : $_.Exception"
+                }
+            }
+        }
+    }
+    else {
+        Write-Warning "$ResourceGroupName has no tags set."
+    }
+}
+
+catch {
+    throw "$_"
+}

--- a/Infrastructure-Scripts/Set-AzResourceTags.ps1
+++ b/Infrastructure-Scripts/Set-AzResourceTags.ps1
@@ -1,14 +1,13 @@
 <#
     .SYNOPSIS
-    Sets standard tags on Resources in a Resource Group to match those on the Resource Group.
+    Sets Tags on All Resources in a Resource Group to match the Tags set on the Resource Group.
 
     .DESCRIPTION
-    Checks if a Resource Group exists,  If it does exist, creates or updates the Standard Tags on any Resource in the Resource Group to match those of the
-    parent Resource group without removing any additions
+    If The Resource Group exists and has been tagged reads the Tags assigned to the Resource Group and replicates them to all Resources within that Resource Group.
+    If there is a Tag with a different Value it will be overwrittend,
 
     .PARAMETER ResourceGroupName
     Name of the Resource Group to be created and/or have tags applied.
-
 
     .EXAMPLE
     Set-ResourceTags -ResourceGroupName "das-at-foobar-rg"

--- a/Infrastructure-Scripts/Set-AzResourceTags.ps1
+++ b/Infrastructure-Scripts/Set-AzResourceTags.ps1
@@ -59,7 +59,7 @@ try {
                     Write-Output $Result
                 }
                 catch {
-                     Write-Error "$($R.Name) - $($Group.ResourceID) : $_.Exception"
+                    Write-Error "$($R.Name) - $($Group.ResourceID) : $_.Exception"
                 }
             }
         }

--- a/Infrastructure-Scripts/Set-AzResourceTags.ps1
+++ b/Infrastructure-Scripts/Set-AzResourceTags.ps1
@@ -23,13 +23,13 @@ try {
     $Group = Get-AzResourceGroup -ResourceGroupName $ResourceGroupName
     if ($null -ne $Group.Tags) {
         $Resources = Get-AzResource -ResourceGroupName $Group.ResourceGroupName
-        foreach ($R in $Resources) {
+        foreach ($Resource in $Resources) {
             $TagChanges = $false
-            $ResourceTags = (Get-AzResource -ResourceId $R.ResourceId).Tags
+            $ResourceTags = (Get-AzResource -ResourceId $Resource.ResourceId).Tags
             if ($ResourceTags) {
                 foreach ($Key in $Group.Tags.Keys) {
                     if (-not($ResourceTags.ContainsKey($Key))) {
-                        Write-Output "ADD: $($R.Name) - $Key"
+                        Write-Output "ADD: $($Resource.Name) - $Key"
                         $ResourceTags.Add($Key, $Group.Tags[$Key])
                         $TagChanges = $true
                     }
@@ -38,7 +38,7 @@ try {
                             # Key is up-to-date
                         }
                         else {
-                            Write-Output "UPD: $($R.Name) - $Key"
+                            Write-Output "UPD: $($Resource.Name) - $Key"
                             $null = $ResourceTags.Remove($Key)
                             $ResourceTags.Add($Key, $Group.Tags[$Key])
                             $TagChanges = $true
@@ -49,17 +49,17 @@ try {
             }
             else {
                 # All tags missing
-                Write-Output "ADD: $($R.Name) - All tags from RG"
+                Write-Output "ADD: $($Resource.Name) - All tags from RG"
                 $TagsToWrite = $Group.Tags
                 $TagChanges = $true
             }
             if ($TagChanges) {
                 try {
-                    $Result = Set-AzResource -Tag $TagsToWrite -ResourceId $R.ResourceId -Force -ErrorAction Stop
+                    $Result = Set-AzResource -Tag $TagsToWrite -ResourceId $Resource.ResourceId -Force -ErrorAction Stop
                     Write-Output $Result
                 }
                 catch {
-                    Write-Error "$($R.Name) - $($Group.ResourceID) : $_.Exception"
+                    Write-Error "$($Resource.Name) - $($Group.ResourceID) : $_.Exception"
                 }
             }
         }

--- a/Infrastructure-Scripts/Set-AzResourceTags.ps1
+++ b/Infrastructure-Scripts/Set-AzResourceTags.ps1
@@ -59,7 +59,7 @@ try {
                     Write-Output $Result
                 }
                 catch {
-                    # Write-Error "$($R.Name) - $($Group.ResourceID) : $_.Exception"
+                     Write-Error "$($R.Name) - $($Group.ResourceID) : $_.Exception"
                 }
             }
         }

--- a/Tests/UT.Set-AzResourceTags.Tests.ps1
+++ b/Tests/UT.Set-AzResourceTags.Tests.ps1
@@ -1,0 +1,55 @@
+$Config = Get-Content $PSScriptRoot\..\Tests\Unit.Tests.Config.json -Raw | ConvertFrom-Json
+Set-Location $PSScriptRoot\..\Infrastructure-Scripts\
+
+Describe "Set-AzResourceTags.ps1 Unit Tests" -Tags @("Unit") {
+
+    Context "ResourceGroup has no tags" {
+        It "Should Output a no tags Warning" {
+            Mock Get-AzResourceGroup -MockWith {
+                return @{
+                    "ResourceGroupName" = $Config.resourceGroupName
+                }
+            }
+            $result =./Set-AzResourceTags -ResourceGroupName $Config.resourceGroupName
+            Assert-MockCalled -CommandName 'Get-AzResourceGroup' -Times 1 -Scope It
+        }
+    }
+
+    Context "Resource Group has Tags" {
+        It "Should add or update tags from resourcegroup to resources" {
+            Mock Get-AzResourceGroup -MockWith {
+                return @{
+                    "ResourceGroupName" = $Config.resourceGroupName
+                    "Tags"              = @{
+                        Environment        = $Config.environment
+                        'Parent Business'  = $Config.parentBusinessTag
+                        'Service Offering' = $Config.serviceOffering
+                    }
+                }
+            }
+            Mock Get-AzResource -MockWith {
+                return @{
+                    "ResourceName" = $Config.resourceName
+                    "ResourceId" = $Config.resourceId
+                    "Tags"              = @{}
+                    }
+                }
+            Mock Set-AzResource -MockWith {
+                return @{
+                    "ResourceName" = $Config.resourceName
+                    "ResourceId" = $Config.resourceId
+                    "Tags"              = @{
+                        Environment        = $Config.environment
+                        'Parent Business'  = $Config.parentBusinessTag
+                        'Service Offering' = $Config.serviceOffering
+                    }
+                }
+            }
+            { ./Set-AzResourceTags -ResourceGroupName $Config.resourceGroupName } | Should Not Throw
+            Assert-MockCalled -CommandName 'Get-AzResourceGroup' -Times 1 -Scope It
+            Assert-MockCalled -CommandName 'Get-AzResource' -Times 2 -Scope It
+            Assert-MockCalled -CommandName 'Set-AzResource' -Times 1 -Scope It
+        }
+    }
+
+}

--- a/Tests/Unit.Tests.Config.json
+++ b/Tests/Unit.Tests.Config.json
@@ -22,5 +22,7 @@
   "CdnProfileName": "aCdnProfile",
   "CdnEndPointName": "aCdnEndpoint",
   "purgeContent": "/*",
-  "blankPurge": " "
+  "blankPurge": " ",
+  "resourceName": "AResource",
+  "resourceId": "AresourceID"
 }


### PR DESCRIPTION
New Script  Set-AzResourceTags.ps1 which sets the tags on all resources to match those of the Resource Group they belong to.

Unit Tests associated with new script

Update to Unit test Config