### PR TITLE
Updated Set-AzResourceGroupTags.ps1 +semver: major

### DIFF
--- a/Infrastructure-Scripts/Set-AzResourceGroupTags.ps1
+++ b/Infrastructure-Scripts/Set-AzResourceGroupTags.ps1
@@ -16,7 +16,7 @@
     A hashtable of the tags to be assigned to the resource group
 
     .EXAMPLE
-    Set-ResourceGroupTags -ResourceGroupName "das-at-foobar-rg" -Tags @{"Parent Business" = "Apprenticeships";"Service Offering" = "AS Commitments"}
+    Set-ResourceGroupTags -ResourceGroupName "das-at-foobar-rg" -Tags @{"Environment" = "Dev/Test";"Parent Business" = "Apprenticeships";"Service Offering" = "AS Commitments"}
 #>
 
 [CmdletBinding()]

--- a/Infrastructure-Scripts/Set-AzResourceGroupTags.ps1
+++ b/Infrastructure-Scripts/Set-AzResourceGroupTags.ps1
@@ -12,17 +12,11 @@
     .PARAMETER Location
     [Optional]Location of the Resource Group, defaults to West Europe.
 
-    .PARAMETER Environment
-    Name of the environment, select from a valid ESFA environment name tag: Production, Pre-Production or Dev/Test.
-
-    .PARAMETER ParentBusiness
-    Name of the business to which the resources belong, e.g. Apprenticeships, Apprenticeships (PP).
-
-    .PARAMETER ServiceOffering
-    Name of the service offering to which the resources belong, e.g. AS Commitments, AS Commitments (PP).
+    .PARAMETER Tags
+    A hashtable of the tags to be assigned to the resource group
 
     .EXAMPLE
-    Set-ResourceGroupTags -ResourceGroupName "das-at-foobar-rg" -Environment "Dev/Test" -ParentBusiness "Apprenticeships" -ServiceOffering "AS Commitments"
+    Set-ResourceGroupTags -ResourceGroupName "das-at-foobar-rg" -Tags @{"Parent Business" = "Apprenticeships";"Service Offering" = "AS Commitments"}
 #>
 
 [CmdletBinding()]
@@ -32,21 +26,10 @@ param(
     [Parameter(Mandatory = $false)]
     [string]$Location = "West Europe",
     [Parameter(Mandatory = $true)]
-    [ValidateSet("Production", "Pre-Production", "Dev/Test", "Prod", "Test", "Dev")]
-    [string]$Environment,
-    [Parameter(Mandatory = $true)]
-    [string]$ParentBusiness,
-    [Parameter(Mandatory = $true)]
-    [string]$ServiceOffering
+    [hashtable]$Tags
 )
 
 try {
-
-    $Tags = @{
-        Environment        = $Environment
-        'Parent Business'  = $ParentBusiness
-        'Service Offering' = $ServiceOffering
-    }
 
     Write-Verbose -Message "Attempting to retrieve existing resource group $ResourceGroupName"
     $ResourceGroup = Get-AzResourceGroup -Name $ResourceGroupName -ErrorAction SilentlyContinue

--- a/Tests/UT.Set-AzResourceGroupTags.Tests.ps1
+++ b/Tests/UT.Set-AzResourceGroupTags.Tests.ps1
@@ -16,7 +16,7 @@ Describe "Set-AzResourceGroupTags.ps1 Unit Tests" -Tags @("Unit") {
                     }
                 }
             }
-            $Result = ./Set-AzResourceGroupTags -ResourceGroupName $Config.resourceGroupName -Environment $Config.environment -ParentBusiness $Config.parentBusinessTag -ServiceOffering $Config.serviceOffering
+            $Result = ./Set-AzResourceGroupTags -ResourceGroupName $Config.resourceGroupName -Tags @{"Environment" = $Config.environment; "Parent Business" = $Config.parentBusinessTag; "Service Offering" = $Config.serviceOffering}
             $Result.Tags.Count | Should Be 3
             Assert-MockCalled -CommandName 'Get-AzResourceGroup' -Times 1 -Scope It
             Assert-MockCalled -CommandName 'New-AzResourceGroup' -Times 1 -Scope It
@@ -35,7 +35,7 @@ Describe "Set-AzResourceGroupTags.ps1 Unit Tests" -Tags @("Unit") {
                     "ResourceGroupName" = $Config.resourceGroupName
                 }
             }
-            { ./Set-AzResourceGroupTags -ResourceGroupName $Config.resourceGroupName -Environment $Config.environment -ParentBusiness $Config.parentBusinessTag -ServiceOffering $Config.serviceOffering } | Should Not Throw
+            { ./Set-AzResourceGroupTags -ResourceGroupName $Config.resourceGroupName -Tags @{"Environment" = $Config.environment; "Parent Business" = $Config.parentBusinessTag; "Service Offering" = $Config.serviceOffering} } | Should Not Throw
             Assert-MockCalled -CommandName 'Get-AzResourceGroup' -Times 1 -Scope It
             Assert-MockCalled -CommandName 'Set-AzResourceGroup' -Times 1 -Scope It
         }


### PR DESCRIPTION
Related Story: https://skillsfundingagency.atlassian.net/browse/DASD-7257

This change is to make the script more flexible and not have set tags in the script.

Passes a hashtable directly as a parameter to process.