### PR TITLE
Replaced IPRangeFilter to IPRules

### DIFF
--- a/Infrastructure-Scripts/Add-CosmosDbIpException.ps1
+++ b/Infrastructure-Scripts/Add-CosmosDbIpException.ps1
@@ -41,21 +41,21 @@ try {
         Write-Output "Processing Cosmos DB Account $ServerName using -AsJob"
         $CosmosDbProperties = (Get-AzResource -ResourceId $CosmosDbAcc.ResourceId).Properties
 
-        if ($CosmosDbProperties.ipRangeFilter.length -eq 0) {
+        if ($CosmosDbProperties.ipRules.length -eq 0) {
             Write-Output "  -> ipRestrictions list is empty for this resource. Skipping."
             continue
         }
 
-        $IPRangeFilterList = [System.Collections.ArrayList]::New($CosmosDbProperties.ipRangeFilter -split ',')
+        $IPRulesFilterList = [System.Collections.ArrayList]::New($CosmosDbProperties.ipRules -split ',')
 
-        if ($IPRangeFilterList -notcontains $IpAddress) {
-            Write-Output "  -> Adding $($IpAddress) to ipRangeFilter ($($CosmosDbProperties.ipRangeFilter))"
-            $null = $IPRangeFilterList.Add($IpAddress.IpAddressToString)
-            $CosmosDbProperties.ipRangeFilter = $IPRangeFilterList -join ','
+        if ($IPRulesFilterList -notcontains $IpAddress) {
+            Write-Output "  -> Adding $($IpAddress) to ipRules ($($CosmosDbProperties.ipRules))"
+            $null = $IPRulesFilterList.Add($IpAddress.IpAddressToString)
+            $CosmosDbProperties.ipRules = $IPRulesFilterList -join ','
             $null = Set-AzResource -ResourceId $CosmosDbAcc.ResourceId -Properties $CosmosDbProperties -Force -AsJob
         }
         else {
-            Write-Output "  -> $IpAddress exists in the current ipRangeFilter. Not updating"
+            Write-Output "  -> $IpAddress exists in the current ipRules. Not updating"
         }
     }
     Write-Output "Waiting for Jobs to complete."


### PR DESCRIPTION
It looks like IPRangeFilter doesn't seem to work, it pulls '0' when queried. I've just checked and it looks like IPRules should be the correct property to query.
```
PS C:\Users\bgowland> $a = Get-AzResource -Name das-pp-prel-cdb -ResourceType "Microsoft.DocumentDb/databaseAccounts"
PS C:\Users\bgowland> $aproperties = (Get-AzResource -ResourceId $a.ResourceId).Properties
PS C:\Users\bgowland> $aproperties.ipRules
ipAddressOrRange
----------------
217.33.132.234
217.33.132.234
104.209.111.99
104.42.195.92
40.76.54.131
52.176.6.30
52.169.50.45
52.187.184.26
0.0.0.0
PS C:\Users\bgowland> $aproperties.ipRules.length
9
PS C:\Users\bgowland> $aproperties.ipRangefilter.length
0
```