### PR TITLE
App role improvements

### DIFF
--- a/Infrastructure-Scripts/Set-AppRoleAssignments/Set-AppRoleAssignments.ps1
+++ b/Infrastructure-Scripts/Set-AppRoleAssignments/Set-AppRoleAssignments.ps1
@@ -109,23 +109,21 @@ try {
                 }
 
                 try {
-                    if ($ServicePrincipal.ObjectId) {
-                        $AppRoleAssignments = Get-AppRoleAssignments -ServicePrincipalId $ServicePrincipal.ObjectId
-                        $AppRoleAssignmentExists = $AppRoleAssignments.value | Where-Object { $_.appRoleId -eq $MatchedAppRole.id -and $_.principalId -eq $ManagedIdentity.ObjectId }
+                    $AppRoleAssignments = Get-AppRoleAssignments -ServicePrincipalId $ServicePrincipal.ObjectId
+                    $AppRoleAssignmentExists = $AppRoleAssignments.value | Where-Object { $_.appRoleId -eq $MatchedAppRole.id -and $_.principalId -eq $ManagedIdentity.ObjectId }
 
-                        if ($AppRoleAssignmentExists) {
-                            Write-Output "      -> App role assignment already exists"
-                            continue
+                    if ($AppRoleAssignmentExists) {
+                        Write-Output "      -> App role assignment already exists"
+                        continue
+                    }
+                    else {
+                        Write-Output "      -> Processing new app role assignment for $ResourceName with role: $($MatchedAppRole.value)"
+
+                        if (!$DryRun) {
+                            New-AppRoleAssignment -ServicePrincipalId $ServicePrincipal.ObjectId -AppRoleId $MatchedAppRole.id -ManagedIdentity $ManagedIdentity.ObjectId
                         }
-                        else {
-                            Write-Output "      -> Processing new app role assignment for $ResourceName with role: $($MatchedAppRole.value)"
 
-                            if (!$DryRun) {
-                                New-AppRoleAssignment -ServicePrincipalId $ServicePrincipal.ObjectId -AppRoleId $MatchedAppRole.id -ManagedIdentity $ManagedIdentity.ObjectId
-                            }
-
-                            Write-Output "      -> Successfully created app role assignment"
-                        }
+                        Write-Output "      -> Successfully created app role assignment"
                     }
                 }
                 catch {

--- a/Infrastructure-Scripts/Set-AppRoleAssignments/tools/Helpers.psm1
+++ b/Infrastructure-Scripts/Set-AppRoleAssignments/tools/Helpers.psm1
@@ -10,11 +10,11 @@ class AppRoleAssignment {
 function Get-Environment {
     Param(
         [Parameter(Mandatory = $true)]
-        [String]$AppServiceName
+        [String]$ResourceName
     )
 
     $ValidEnvironments = @("at", "test", "test2", "demo", "pp", "prd", "mo")
-    $Environment = $AppServiceName.Split('-')[1]
+    $Environment = $ResourceName.Split('-')[1]
 
     if ($Environment -in $ValidEnvironments) {
         return $Environment

--- a/Tests/UT.Set-AppRoleAssignments.Tests.ps1
+++ b/Tests/UT.Set-AppRoleAssignments.Tests.ps1
@@ -44,7 +44,12 @@ Describe "Set-AppRoleAssignments Unit Tests" -Tags @("Unit") {
 
         It "Single service principal found" {
 
-            Mock Get-ServicePrincipal -MockWith { @("") }
+            Mock Get-ServicePrincipal -MockWith {
+                return @{
+                    ObjectId = $Config.resourceId
+                }
+            }
+            Mock Get-AppRoleAssignments -MockWith { }
             Mock Write-Output { }
             $AppServiceName = "das-test-ui-as"
 

--- a/Tests/UT.Set-AppRoleAssignments.Tests.ps1
+++ b/Tests/UT.Set-AppRoleAssignments.Tests.ps1
@@ -7,7 +7,7 @@ Describe "Set-AppRoleAssignments Unit Tests" -Tags @("Unit") {
         It "The extracted environment from app service name is invalid, throw an error" {
 
             $AppServiceName = "das-poc-ui-as"
-            { ./Set-AppRoleAssignments -AppRegistrationConfigurationFilePath "$PSScriptRoot\..\Tests\Configuration\Set-AppRoleAssignments.Config.json" -AppServiceName $AppServiceName -Tenant $Config.Tenant -DryRun $true} | Should Throw "Environment retrieved from app service name not valid"
+            { ./Set-AppRoleAssignments -AppRegistrationConfigurationFilePath "$PSScriptRoot\..\Tests\Configuration\Set-AppRoleAssignments.Config.json" -ResourceName $AppServiceName -Tenant $Config.Tenant -DryRun $true} | Should Throw "Environment retrieved from app service name not valid"
 
         }
     }
@@ -16,7 +16,7 @@ Describe "Set-AppRoleAssignments Unit Tests" -Tags @("Unit") {
         It "No app registrations found to process, throw an error" {
 
             $AppServiceName = "das-test-foobar-as"
-            { ./Set-AppRoleAssignments -AppRegistrationConfigurationFilePath "$PSScriptRoot\..\Tests\Configuration\Set-AppRoleAssignments.Config.json" -AppServiceName $AppServiceName -Tenant $Config.Tenant -DryRun $true } | Should Throw "No app registrations to process for app service name $AppServiceName"
+            { ./Set-AppRoleAssignments -AppRegistrationConfigurationFilePath "$PSScriptRoot\..\Tests\Configuration\Set-AppRoleAssignments.Config.json" -ResourceName $AppServiceName -Tenant $Config.Tenant -DryRun $true } | Should Throw "No app registrations to process for app service name $AppServiceName"
 
         }
     }
@@ -27,7 +27,7 @@ Describe "Set-AppRoleAssignments Unit Tests" -Tags @("Unit") {
             Mock Get-ServicePrincipal -MockWith { return @("", "") }
             $AppServiceName = "das-test-ui-as"
 
-            { ./Set-AppRoleAssignments -AppRegistrationConfigurationFilePath "$PSScriptRoot\..\Tests\Configuration\Set-AppRoleAssignments.Config.json" -AppServiceName $AppServiceName -Tenant $Config.Tenant -DryRun $true } | Should Throw
+            { ./Set-AppRoleAssignments -AppRegistrationConfigurationFilePath "$PSScriptRoot\..\Tests\Configuration\Set-AppRoleAssignments.Config.json" -ResourceName $AppServiceName -Tenant $Config.Tenant -DryRun $true } | Should Throw
             Assert-MockCalled Get-ServicePrincipal -Times 1
 
         }
@@ -38,7 +38,7 @@ Describe "Set-AppRoleAssignments Unit Tests" -Tags @("Unit") {
             Mock Write-Output {}
             $AppServiceName = "das-test-ui-as"
 
-            { ./Set-AppRoleAssignments -AppRegistrationConfigurationFilePath "$PSScriptRoot\..\Tests\Configuration\Set-AppRoleAssignments.Config.json" -AppServiceName $AppServiceName -Tenant $Config.Tenant -DryRun $true } | Should Not Throw
+            { ./Set-AppRoleAssignments -AppRegistrationConfigurationFilePath "$PSScriptRoot\..\Tests\Configuration\Set-AppRoleAssignments.Config.json" -ResourceName $AppServiceName -Tenant $Config.Tenant -DryRun $true } | Should Not Throw
             Assert-MockCalled Write-Output -Times 2 -Scope It -ParameterFilter { $InputObject -match "not found in AAD - Creating" }
         }
 
@@ -48,7 +48,7 @@ Describe "Set-AppRoleAssignments Unit Tests" -Tags @("Unit") {
             Mock Write-Output { }
             $AppServiceName = "das-test-ui-as"
 
-            { ./Set-AppRoleAssignments -AppRegistrationConfigurationFilePath "$PSScriptRoot\..\Tests\Configuration\Set-AppRoleAssignments.Config.json" -AppServiceName $AppServiceName -Tenant $Config.Tenant -DryRun $true } | Should Not Throw
+            { ./Set-AppRoleAssignments -AppRegistrationConfigurationFilePath "$PSScriptRoot\..\Tests\Configuration\Set-AppRoleAssignments.Config.json" -ResourceName $AppServiceName -Tenant $Config.Tenant -DryRun $true } | Should Not Throw
             Assert-MockCalled Write-Output -Times 2 -Scope It -ParameterFilter { $InputObject -match "-> Processing app registration" }
         }
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -102,4 +102,4 @@ stages:
                   tagSource: "manual"
                   tag: "$(Build.BuildNumber)"
                   addChangeLog: true
-                  assets: $(Pipeline.Workspace)/Infrastructure-Scripts/*
+                  assets: $(Pipeline.Workspace)/Infrastructure-Scripts/**/*.ps1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -102,4 +102,4 @@ stages:
                   tagSource: "manual"
                   tag: "$(Build.BuildNumber)"
                   addChangeLog: true
-                  assets: "$(Pipeline.Workspace)/Infrastructure-Scripts/**/*.ps1"
+                  assets: $(Pipeline.Workspace)/Infrastructure-Scripts/*


### PR DESCRIPTION
- Fixed code path where a new app role assignment would not be processed if one already existed
- Reverted assets filepath
- Changed parameter from AppServiceName to ResourceName (as we process APIM MI's as well)
- Only process app roles of ResourceName passed in