### PR TITLE
Import swagger script ApiId change

### DIFF
--- a/Infrastructure-Scripts/Import-ApimSwaggerApiDefinition.ps1
+++ b/Infrastructure-Scripts/Import-ApimSwaggerApiDefinition.ps1
@@ -93,6 +93,7 @@ function Get-SwaggerFilePath ($IndexHtml) {
 
 function Get-ApiTitle ($SwaggerSpecificationUrl) {
     $ApiTitle = ((Invoke-RetryWebRequest $SwaggerSpecificationUrl).Content | ConvertFrom-Json).info.title
+    $ApiTitle
 }
 
 function Get-AppServiceName ($ApiBaseUrl, $AppServiceResourceGroup) {

--- a/Infrastructure-Scripts/Import-ApimSwaggerApiDefinition.ps1
+++ b/Infrastructure-Scripts/Import-ApimSwaggerApiDefinition.ps1
@@ -93,7 +93,6 @@ function Get-SwaggerFilePath ($IndexHtml) {
 
 function Get-ApiTitle ($SwaggerSpecificationUrl) {
     $ApiTitle = ((Invoke-RetryWebRequest $SwaggerSpecificationUrl).Content | ConvertFrom-Json).info.title
-    $ApiTitle
 }
 
 function Get-AppServiceName ($ApiBaseUrl, $AppServiceResourceGroup) {
@@ -137,7 +136,7 @@ foreach ($SwaggerPath in $SwaggerPaths) {
     $SwaggerPath -match '\d' | Out-Null
     $Version = $matches[0]
     $ApiTitle = Get-ApiTitle $SwaggerSpecificationUrl
-    $ApiId = "$ApiTitle-v" + $Version.ToUpper()
+    $ApiId = $ApiTitle.replace(" ","-") + "-v" + $Version.ToUpper()
 
     $VersionSet = Get-AzApiManagementApiVersionSet -Context $Context | Where-Object { $_.DisplayName -eq "$ApiVersionSetName" }
     if ($null -eq $VersionSet) {

--- a/Tests/UT.Import-ApimSwaggerApiDefinition.Tests.ps1
+++ b/Tests/UT.Import-ApimSwaggerApiDefinition.Tests.ps1
@@ -39,7 +39,7 @@ Describe "Import-ApimSwaggerApiDefinition Unit Tests" -Tags @("Unit") {
             Mock Invoke-RetryWebRequest -MockWith { Return $null }
             Mock Start-Sleep -MockWith { Return $null }
             Mock Get-SwaggerFilePath -MockWith { Return @("/swagger/v1/swagger.json", "/swagger/v2/swagger.json") }
-            Mock Get-ApiTitle -MockWith { Return $null }
+            Mock Get-ApiTitle -MockWith { Return "ApiTitle" }
             Mock Get-AzApiManagementApiVersionSet -MockWith {
                 return @{
                     "Id"          = $Config.resourceId


### PR DESCRIPTION
This change is to fix cases where there is whitespaces in the title in the swagger definitions and erroring when trying to create an API in APIM with that title