### PR TITLE
Changed object id to id for app role assignments +semver: major

### DIFF
--- a/Infrastructure-Scripts/Invoke-CdnContentPurge.ps1
+++ b/Infrastructure-Scripts/Invoke-CdnContentPurge.ps1
@@ -44,7 +44,7 @@ try {
         throw "CDN Endpoint does not exist"
     }
     # --- Purging CDN EndPoint
-    $CDNEndpoint | Unpublish-AzCdnEndpointContent -PurgeContent $PurgeContent
+    $CDNEndpoint | Clear-AzCdnEndpointContent -ContentPath $PurgeContent
 }
 catch {
     throw "$_"

--- a/Infrastructure-Scripts/Set-AppRoleAssignments/Set-AppRoleAssignments.ps1
+++ b/Infrastructure-Scripts/Set-AppRoleAssignments/Set-AppRoleAssignments.ps1
@@ -76,7 +76,7 @@ try {
                 $AppRegistrationObject = New-AppRegistration -AppRegistrationName $AppRegistrationName -IdentifierUri $IdentifierUri
                 #Allow Azure CLI to acquire tokens
                 $ServicePrincipal = Get-ServicePrincipal -DisplayName $AppRegistrationName
-                Set-AzureCLIAccess -IdentifierUri $IdentifierUri -ServicePrincipalObjectId $ServicePrincipal.objectId -AppRegistrationObjectId $AppRegistrationObject.objectId -AppRegistrationOauth2PermissionsId $AppRegistrationObject.Oauth2Permissions.id
+                Set-AzureCLIAccess -IdentifierUri $IdentifierUri -ServicePrincipalObjectId $ServicePrincipal.id -AppRegistrationObjectId $AppRegistrationObject.id -AppRegistrationOauth2PermissionsId $AppRegistrationObject.Oauth2Permissions.id
             }
 
             Write-Output "  -> Successfully created app registration - $AppRegistrationName"
@@ -118,8 +118,8 @@ try {
 
                 try {
                     #Assign app managed identities to app role
-                    $AppRoleAssignments = Get-AppRoleAssignments -ServicePrincipalId $ServicePrincipal.ObjectId
-                    $AppRoleAssignmentExists = $AppRoleAssignments.value | Where-Object { $_.appRoleId -eq $MatchedAppRole.id -and $_.principalId -eq $ManagedIdentity.ObjectId }
+                    $AppRoleAssignments = Get-AppRoleAssignments -ServicePrincipalId $ServicePrincipal.id
+                    $AppRoleAssignmentExists = $AppRoleAssignments.value | Where-Object { $_.appRoleId -eq $MatchedAppRole.id -and $_.principalId -eq $ManagedIdentity.id }
 
                     if ($AppRoleAssignmentExists) {
                         Write-Output "      -> App role assignment already exists"
@@ -128,7 +128,7 @@ try {
                         Write-Output "      -> Processing new app role assignment for $ResourceName with role: $($MatchedAppRole.value)"
 
                         if (!$DryRun) {
-                            New-AppRoleAssignment -ServicePrincipalId $ServicePrincipal.ObjectId -AppRoleId $MatchedAppRole.id -ManagedIdentity $ManagedIdentity.ObjectId -PrincipalType "ServicePrincipal"
+                            New-AppRoleAssignment -ServicePrincipalId $ServicePrincipal.id -AppRoleId $MatchedAppRole.id -ManagedIdentity $ManagedIdentity.id -PrincipalType "ServicePrincipal"
                         }
 
                         Write-Output "      -> Successfully created app role assignment"
@@ -146,7 +146,7 @@ try {
 
                             if ($Environment -in @("at", "test", "test2", "demo", "pp")) {
                                 if (!$DryRun) {
-                                    New-AppRoleAssignment -ServicePrincipalId $ServicePrincipal.ObjectId -AppRoleId $MatchedAppRole.id -ManagedIdentity $AadGroupObjectId -PrincipalType "Group"
+                                    New-AppRoleAssignment -ServicePrincipalId $ServicePrincipal.id -AppRoleId $MatchedAppRole.id -ManagedIdentity $AadGroupObjectId -PrincipalType "Group"
                                 }
                             }
 

--- a/Tests/UT.Invoke-CdnContentPurge.Tests.ps1
+++ b/Tests/UT.Invoke-CdnContentPurge.Tests.ps1
@@ -18,15 +18,15 @@ Describe "Invoke-CdnContentPurge Unit Tests" -Tags @("Unit") {
     }
 
     Context "Parameters are ok" {
-        It "Should call Unpublish-AzCdnEndpointContent" {
+        It "Should call Clear-AzCdnEndpointContent" {
             Mock Get-AzCdnEndpoint -MockWith {
                 $cdnEndpointExists = [Microsoft.Azure.Commands.Cdn.Models.Endpoint.PSEndpoint]::new()
                 return $cdnEndpointExists
             }
-            Mock Unpublish-AzCdnEndpointContent -MockWith { Return $null }
+            Mock Clear-AzCdnEndpointContent -MockWith { Return $null }
             { ./Invoke-CdnContentPurge -CDNProfileResourceGroup $Config.resourceGroupName -CDNProfileName $Config.CdnProfileName -CDNEndPointName $Config.CDNEndPointName -PurgeContent $Config.purgeContent } | Should Not Throw
             Assert-MockCalled -CommandName 'Get-AzCdnEndpoint' -Times 1 -Scope It
-            Assert-MockCalled -CommandName 'Unpublish-AzCdnEndpointContent' -Times 1 -Scope It
+            Assert-MockCalled -CommandName 'Clear-AzCdnEndpointContent' -Times 1 -Scope It
         }
     }
 }

--- a/Tests/UT.Invoke-CdnContentPurge.Tests.ps1
+++ b/Tests/UT.Invoke-CdnContentPurge.Tests.ps1
@@ -20,7 +20,7 @@ Describe "Invoke-CdnContentPurge Unit Tests" -Tags @("Unit") {
     Context "Parameters are ok" {
         It "Should call Clear-AzCdnEndpointContent" {
             Mock Get-AzCdnEndpoint -MockWith {
-                $cdnEndpointExists = [Microsoft.Azure.Commands.Cdn.Models.Endpoint.PSEndpoint]::new()
+                $cdnEndpointExists = [Microsoft.Azure.PowerShell.Cmdlets.Cdn.Models.Api20210601.Endpoint]::new()
                 return $cdnEndpointExists
             }
             Mock Clear-AzCdnEndpointContent -MockWith { Return $null }

--- a/Tests/UT.Set-AppRoleAssignments.Tests.ps1
+++ b/Tests/UT.Set-AppRoleAssignments.Tests.ps1
@@ -46,7 +46,7 @@ Describe "Set-AppRoleAssignments Unit Tests" -Tags @("Unit") {
 
             Mock Get-ServicePrincipal -MockWith {
                 return @{
-                    ObjectId = $Config.resourceId
+                    Id = $Config.resourceId
                 }
             }
             Mock Get-AppRoleAssignments -MockWith { }


### PR DESCRIPTION
https://docs.microsoft.com/en-gb/cli/azure/microsoft-graph-migration?tabs=powershell#breaking-changes

> For example, the most outstanding change is that the objectId property in the output JSON of a Graph object is replaced by id.