### PR TITLE
Alterations to app service whitelist scripts +semver: major

### DIFF
--- a/Infrastructure-Scripts/Add-AppServiceIpException.ps1
+++ b/Infrastructure-Scripts/Add-AppServiceIpException.ps1
@@ -15,7 +15,8 @@
     The name of the rule being created
 
     .EXAMPLE
-    Add-AppServiceIpException -IpAddress 192.168.0.1 -ResourceNames das-foobar -RuleName foobar
+    Add-AppServiceIpException -IpAddress 192.168.0.1 -ResourceNames "das-foobar" -RuleName foobar
+    Add-AppServiceIpException -IpAddress 192.168.0.1 -ResourceNames "das-foobar", "das-barfoo" -RuleName foobar
 #>
 
 [CmdletBinding()]

--- a/Infrastructure-Scripts/Add-AppServiceIpException.ps1
+++ b/Infrastructure-Scripts/Add-AppServiceIpException.ps1
@@ -9,7 +9,7 @@
     An ip address to associate with the access restriction rule
 
     .PARAMETER ResourceNames
-    The name of the app service
+    The names of the app services required to be looped through. This can be a singular or multiple app services.
 
     .PARAMETER RuleName
     The name of the rule being created

--- a/Infrastructure-Scripts/Add-AppServiceIpException.ps1
+++ b/Infrastructure-Scripts/Add-AppServiceIpException.ps1
@@ -30,7 +30,13 @@ Param (
     [ValidateNotNull()]
     [String]$RuleName
 )
-    $RuleName = $RuleName.Replace(' ', '')
+    if ($RuleName.Length -le 32) {
+        $RuleName = $RuleName.Replace(' ', '')
+    }
+    else {
+        $RuleName = "TEMPORARY_WHITELIST"
+    }
+
     $AppServiceResource = Get-AzResource -Name $ResourceName -ResourceType "Microsoft.Web/sites"
 
     if (!$AppServiceResource) {
@@ -41,7 +47,7 @@ Param (
     Write-Output "Processing app service: $ResourceName ..."
 
     if (($AppServiceResourceConfig.MainSiteAccessRestrictions.Count) -gt 1){
-        Write-Output "Creating rule: $RuleName"
+        Write-Output "  -> Creating rule: $RuleName"
 
         # --- Workout next priority number
         $StartPriority = 100
@@ -56,8 +62,8 @@ Param (
 
         Write-Output "  -> Rule priority set to $NewPriority"
         Add-AzWebAppAccessRestrictionRule -ResourceGroupName $AppServiceResource.ResourceGroupName -WebAppName $ResourceName -Name $RuleName -Priority $NewPriority -Action "Allow" -IpAddress "$IpAddress/32"
+        Write-Output "  -> Rule created successfully."
     }
     else{
-        Write-Output "There are no existing access restrictions on $ResourceName. Whitelist is not required."
+        Write-Output "  -> There are no existing access restrictions on $ResourceName. Whitelist is not required."
     }
-

--- a/Infrastructure-Scripts/Add-AppServiceIpException.ps1
+++ b/Infrastructure-Scripts/Add-AppServiceIpException.ps1
@@ -1,9 +1,9 @@
 <#
     .SYNOPSIS
-    Update the access restriction rules for an app service
+    Update the access restriction rules for a singular or multiple app services.
 
     .DESCRIPTION
-    Update the access restriction rules for an app service
+    Update the access restriction rules for a singular or multiple app services.
 
     .PARAMETER IpAddress
     An ip address to associate with the access restriction rule

--- a/Infrastructure-Scripts/Add-AppServiceIpException.ps1
+++ b/Infrastructure-Scripts/Add-AppServiceIpException.ps1
@@ -8,14 +8,14 @@
     .PARAMETER IpAddress
     An ip address to associate with the access restriction rule
 
-    .PARAMETER ResourceName
+    .PARAMETER ResourceNames
     The name of the app service
 
     .PARAMETER RuleName
     The name of the rule being created
 
     .EXAMPLE
-    Add-AppServiceIpException -IpAddress 192.168.0.1 -ResourceName das-foobar
+    Add-AppServiceIpException -IpAddress 192.168.0.1 -ResourceNames das-foobar -RuleName foobar
 #>
 
 [CmdletBinding()]
@@ -25,14 +25,14 @@ Param (
     [IPAddress]$IpAddress,
     [Parameter(Mandatory = $true)]
     [ValidateNotNull()]
-    [String[]]$ResourceName,
+    [String[]]$ResourceNames,
     [Parameter(Mandatory = $true)]
     [ValidateNotNull()]
     [ValidateLength(1,32)]
     [String]$RuleName
 )
 
-foreach ($Resource in $ResourceName){
+foreach ($Resource in $ResourceNames){
 
     $AppServiceResource = Get-AzResource -Name $Resource -ResourceType "Microsoft.Web/sites"
 

--- a/Infrastructure-Scripts/Add-AppServiceIpException.ps1
+++ b/Infrastructure-Scripts/Add-AppServiceIpException.ps1
@@ -28,42 +28,37 @@ Param (
     [String]$ResourceName,
     [Parameter(Mandatory = $true)]
     [ValidateNotNull()]
+    [ValidateLength(1,32)]
     [String]$RuleName
 )
-    if ($RuleName.Length -le 32) {
-        $RuleName = $RuleName.Replace(' ', '')
+
+$AppServiceResource = Get-AzResource -Name $ResourceName -ResourceType "Microsoft.Web/sites"
+
+if (!$AppServiceResource) {
+    throw "Could not find a resource matching $ResourceName in the subscription"
+}
+
+$AppServiceResourceConfig = Get-AzWebAppAccessRestrictionConfig -ResourceGroupName $AppServiceResource.ResourceGroupName -Name $ResourceName
+Write-Output "Processing app service: $ResourceName ..."
+
+if (($AppServiceResourceConfig.MainSiteAccessRestrictions.Count) -gt 1){
+    Write-Output "  -> Creating rule: $RuleName"
+
+    # --- Workout next priority number
+    $StartPriority = 100
+    $ExistingPriority = ($AppServiceResourceConfig.MainSiteAccessRestrictions.priority | Where-Object { ($_ -ge $StartPriority) -and $_ -lt [int32]::MaxValue } | Measure-Object -Maximum).Maximum
+
+    if (!$ExistingPriority) {
+        $NewPriority = $StartPriority
     }
     else {
-        $RuleName = "TEMPORARY_WHITELIST"
+        $NewPriority = $ExistingPriority + 1
     }
 
-    $AppServiceResource = Get-AzResource -Name $ResourceName -ResourceType "Microsoft.Web/sites"
-
-    if (!$AppServiceResource) {
-        throw "Could not find a resource matching $ResourceName in the subscription"
-    }
-
-    $AppServiceResourceConfig = Get-AzWebAppAccessRestrictionConfig -ResourceGroupName $AppServiceResource.ResourceGroupName -Name $ResourceName
-    Write-Output "Processing app service: $ResourceName ..."
-
-    if (($AppServiceResourceConfig.MainSiteAccessRestrictions.Count) -gt 1){
-        Write-Output "  -> Creating rule: $RuleName"
-
-        # --- Workout next priority number
-        $StartPriority = 100
-        $ExistingPriority = ($AppServiceResourceConfig.MainSiteAccessRestrictions.priority | Where-Object { ($_ -ge $StartPriority) -and $_ -lt [int32]::MaxValue } | Measure-Object -Maximum).Maximum
-
-        if (!$ExistingPriority) {
-            $NewPriority = $StartPriority
-        }
-        else {
-            $NewPriority = $ExistingPriority + 1
-        }
-
-        Write-Output "  -> Rule priority set to $NewPriority"
-        Add-AzWebAppAccessRestrictionRule -ResourceGroupName $AppServiceResource.ResourceGroupName -WebAppName $ResourceName -Name $RuleName -Priority $NewPriority -Action "Allow" -IpAddress "$IpAddress/32"
-        Write-Output "  -> Rule created successfully."
-    }
-    else{
-        Write-Output "  -> There are no existing access restrictions on $ResourceName. Whitelist is not required."
-    }
+    Write-Output "  -> Rule priority set to $NewPriority"
+    Add-AzWebAppAccessRestrictionRule -ResourceGroupName $AppServiceResource.ResourceGroupName -WebAppName $ResourceName -Name $RuleName -Priority $NewPriority -Action "Allow" -IpAddress "$IpAddress/32"
+    Write-Output "  -> Rule created successfully."
+}
+else{
+    Write-Output "  -> There are no existing access restrictions on $ResourceName. Whitelist is not required."
+}

--- a/Infrastructure-Scripts/Remove-AppServiceIpException.ps1
+++ b/Infrastructure-Scripts/Remove-AppServiceIpException.ps1
@@ -12,7 +12,8 @@
     The names of the app services required to be looped through. This can be a singular or multiple app services.
 
     .EXAMPLE
-    Remove-AppServiceIpException -IPAddress 192.168.0.1 -ResourceNames das-foobar
+    Remove-AppServiceIpException -IPAddress 192.168.0.1 -ResourceNames "das-foobar"
+    Remove-AppServiceIpException -IPAddress 192.168.0.1 -ResourceNames "das-foobar", "das-barfoo"
 #>
 
 [CmdletBinding()]

--- a/Infrastructure-Scripts/Remove-AppServiceIpException.ps1
+++ b/Infrastructure-Scripts/Remove-AppServiceIpException.ps1
@@ -9,7 +9,7 @@
     An ip address to associate with the access restriction rule
 
     .PARAMETER ResourceNames
-    The name of the app service
+    The names of the app services required to be looped through. This can be a singular or multiple app services.
 
     .EXAMPLE
     Remove-AppServiceIpException -IPAddress 192.168.0.1 -ResourceNames das-foobar

--- a/Infrastructure-Scripts/Remove-AppServiceIpException.ps1
+++ b/Infrastructure-Scripts/Remove-AppServiceIpException.ps1
@@ -8,11 +8,11 @@
     .PARAMETER IpAddress
     An ip address to associate with the access restriction rule
 
-    .PARAMETER ResourceName
+    .PARAMETER ResourceNames
     The name of the app service
 
     .EXAMPLE
-    Remove-AppServiceIpException -IPAddress 192.168.0.1 -ResourceName das-foobar
+    Remove-AppServiceIpException -IPAddress 192.168.0.1 -ResourceNames das-foobar
 #>
 
 [CmdletBinding()]
@@ -22,10 +22,10 @@ Param (
     [IPAddress]$IPAddress,
     [Parameter(Mandatory = $true)]
     [ValidateNotNull()]
-    [String[]]$ResourceName
+    [String[]]$ResourceNames
 )
 
-foreach ($Resource in $ResourceName){
+foreach ($Resource in $ResourceNames){
 
     $AppServiceResource = Get-AzResource -Name $Resource -ResourceType "Microsoft.Web/sites"
 

--- a/Infrastructure-Scripts/Remove-AppServiceIpException.ps1
+++ b/Infrastructure-Scripts/Remove-AppServiceIpException.ps1
@@ -1,9 +1,9 @@
 <#
     .SYNOPSIS
-    Removes an IP address access restriction rule from an app service
+    Removes an IP address access restriction rule from an app service or multiple app services.
 
     .DESCRIPTION
-    Removes an IP address access restriction rule from an app service
+    Removes an IP address access restriction rule from an app service or multiple app services.
 
     .PARAMETER IpAddress
     An ip address to associate with the access restriction rule

--- a/Infrastructure-Scripts/Remove-AppServiceIpException.ps1
+++ b/Infrastructure-Scripts/Remove-AppServiceIpException.ps1
@@ -22,23 +22,25 @@ Param (
     [IPAddress]$IPAddress,
     [Parameter(Mandatory = $true)]
     [ValidateNotNull()]
-    [String]$ResourceName
+    [String[]]$ResourceName
 )
 
+foreach ($Resource in $ResourceName){
 
-$AppServiceResource = Get-AzResource -Name $ResourceName -ResourceType "Microsoft.Web/sites"
+    $AppServiceResource = Get-AzResource -Name $Resource -ResourceType "Microsoft.Web/sites"
 
-if (!$AppServiceResource) {
-    throw "Could not find a resource matching $ResourceName in the subscription"
-}
+    if (!$AppServiceResource) {
+        throw "Could not find a resource matching $Resource in the subscription"
+    }
 
-$AppServiceWhitelist = Get-AzWebAppAccessRestrictionConfig -ResourceGroupName $AppServiceResource.ResourceGroupName -Name $ResourceName | Where-Object { $_.MainSiteAccessRestrictions.IpAddress -eq "$IPAddress/32" }
+    $AppServiceWhitelist = Get-AzWebAppAccessRestrictionConfig -ResourceGroupName $AppServiceResource.ResourceGroupName -Name $Resource | Where-Object { $_.MainSiteAccessRestrictions.IpAddress -eq "$IPAddress/32" }
 
-if (!$AppServiceWhitelist) {
-    Write-Output " -> Could not find whitelisted $IPAddress to remove on $ResourceName!"
-}
-else {
-    Write-Output "  -> Removing $IPAddress from $ResourceName"
-    Remove-AzWebAppAccessRestrictionRule  -ResourceGroupName $AppServiceResource.ResourceGroupName -WebAppName $ResourceName -IpAddress "$IPAddress/32"
-    Write-Output "  -> $IPAddress, removed from $ResourceName!"
+    if (!$AppServiceWhitelist) {
+        Write-Output " -> Could not find whitelisted $IPAddress to remove on $Resource!"
+    }
+    else {
+        Write-Output "  -> Removing $IPAddress from $Resource"
+        Remove-AzWebAppAccessRestrictionRule  -ResourceGroupName $AppServiceResource.ResourceGroupName -WebAppName $Resource -IpAddress "$IPAddress/32"
+        Write-Output "  -> $IPAddress, removed from $Resource!"
+    }
 }

--- a/Tests/Configuration/Unit.Tests.Config.json
+++ b/Tests/Configuration/Unit.Tests.Config.json
@@ -58,5 +58,7 @@
   "nameIpAddressObject": "[{'IpAddressA':'10.0.0.0/32','IpAddressB':'10.0.0.1/32'}]",
   "invalidJson": "[{",
   "guid": "8bb58c80-06f9-4007-ba54-1f7e919c16d7",
-  "aadGroupObjectIdArray": "['a','b','c']"
+  "aadGroupObjectIdArray": "['a','b','c']",
+  "whitelistResourceName": ["AResource","BResource"],
+  "whitelistResourceNameSingle": ["AResource"]
 }

--- a/Tests/UT.Add-AppServiceIpException.Tests.ps1
+++ b/Tests/UT.Add-AppServiceIpException.Tests.ps1
@@ -8,7 +8,7 @@ Describe "Add-AppServiceIpException Unit Tests" -Tags @("Unit") {
     Context "Resource does not exist" {
         It "The specified Resource was not found in the subscription, throw an error" {
             Mock Get-AzResource -MockWith { return $null }
-            { ./Add-AppServiceIpException -IpAddress $Config.ipAddress -ResourceName $Config.resourceName } | Should throw "Could not find a resource matching $($config.resourceName) in the subscription"
+            { ./Add-AppServiceIpException -IpAddress $Config.ipAddress -ResourceName $Config.resourceName -RuleName $Config.ruleName } | Should throw "Could not find a resource matching $($config.resourceName) in the subscription"
             Assert-MockCalled -CommandName 'Get-AzResource' -Times 1 -Scope It
         }
     }
@@ -21,7 +21,7 @@ Describe "Add-AppServiceIpException Unit Tests" -Tags @("Unit") {
                 }
             }
             Mock Get-AzWebAppAccessRestrictionConfig -MockWith { throw "Operation returned an invalid status code 'NotFound'" }
-            { ./Add-AppServiceIpException -IpAddress $Config.ipAddress -ResourceName $Config.resourceName } | Should throw
+            { ./Add-AppServiceIpException -IpAddress $Config.ipAddress -ResourceName $Config.resourceName -RuleName $Config.ruleName } | Should throw
             Assert-MockCalled -CommandName 'Get-AzResource' -Times 1 -Scope It
             Assert-MockCalled -CommandName 'Get-AzWebAppAccessRestrictionConfig' -Times 1 -Scope It
         }
@@ -34,12 +34,31 @@ Describe "Add-AppServiceIpException Unit Tests" -Tags @("Unit") {
                     "Name"              = $Config.resourceName
                 }
             }
-            Mock Get-AzWebAppAccessRestrictionConfig -MockWith { return $null }
+            Mock Get-AzWebAppAccessRestrictionConfig -MockWith { return @{
+                "MainSiteAccessRestrictions" = @("foo","bar")
+                } 
+            }
             Mock Add-AzWebAppAccessRestrictionRule -MockWith { return $null }
-            { ./Add-AppServiceIpException -IpAddress $Config.ipAddress -ResourceName $Config.resourceName } | Should Not throw
+            { ./Add-AppServiceIpException -IpAddress $Config.ipAddress -ResourceName $Config.resourceName -RuleName $Config.ruleName } | Should Not throw
             Assert-MockCalled -CommandName 'Get-AzResource' -Times 1 -Scope It
             Assert-MockCalled -CommandName 'Get-AzWebAppAccessRestrictionConfig' -Times 1 -Scope It
             Assert-MockCalled -CommandName 'Add-AzWebAppAccessRestrictionRule' -Times 1 -Scope It
+        }
+    }
+
+    Context "Resource exists but does not have access restrictions" {
+        It "The specified Resource Config was identified to not have network restrictions, no whitelist required." {
+            Mock Get-AzResource -MockWith { return @{
+                    "ResourceGroupName" = $Config.resourceGroupName
+                    "Name"              = $Config.resourceName
+                }
+            }
+            Mock Get-AzWebAppAccessRestrictionConfig -MockWith { return $null }
+            Mock Add-AzWebAppAccessRestrictionRule -MockWith { return $null }
+            { ./Add-AppServiceIpException -IpAddress $Config.ipAddress -ResourceName $Config.resourceName -RuleName $Config.ruleName } | Should Not throw
+            Assert-MockCalled -CommandName 'Get-AzResource' -Times 1 -Scope It
+            Assert-MockCalled -CommandName 'Get-AzWebAppAccessRestrictionConfig' -Times 1 -Scope It
+            Assert-MockCalled -CommandName 'Add-AzWebAppAccessRestrictionRule' -Times 0 -Scope It
         }
     }
 }

--- a/Tests/UT.Add-AppServiceIpException.Tests.ps1
+++ b/Tests/UT.Add-AppServiceIpException.Tests.ps1
@@ -8,7 +8,7 @@ Describe "Add-AppServiceIpException Unit Tests" -Tags @("Unit") {
     Context "Resource does not exist" {
         It "The specified Resource was not found in the subscription, throw an error" {
             Mock Get-AzResource -MockWith { return $null }
-            { ./Add-AppServiceIpException -IpAddress $Config.ipAddress -ResourceName $Config.resourceName -RuleName $Config.ruleName } | Should throw "Could not find a resource matching $($config.resourceName) in the subscription"
+            { ./Add-AppServiceIpException -IpAddress $Config.ipAddress -ResourceName $Config.whitelistResourceName -RuleName $Config.ruleName } | Should throw "Could not find a resource matching AResource in the subscription"
             Assert-MockCalled -CommandName 'Get-AzResource' -Times 1 -Scope It
         }
     }
@@ -17,11 +17,11 @@ Describe "Add-AppServiceIpException Unit Tests" -Tags @("Unit") {
         It "The specified Resource Config was not found, throw an error" {
             Mock Get-AzResource -MockWith { return @{
                     "ResourceGroupName" = $Config.resourceGroupName
-                    "Name"              = $Config.resourceName
+                    "Name"              = $Config.whitelistResourceName[0]
                 }
             }
             Mock Get-AzWebAppAccessRestrictionConfig -MockWith { throw "Operation returned an invalid status code 'NotFound'" }
-            { ./Add-AppServiceIpException -IpAddress $Config.ipAddress -ResourceName $Config.resourceName -RuleName $Config.ruleName } | Should throw
+            { ./Add-AppServiceIpException -IpAddress $Config.ipAddress -ResourceName $Config.whitelistResourceName[0] -RuleName $Config.ruleName } | Should throw
             Assert-MockCalled -CommandName 'Get-AzResource' -Times 1 -Scope It
             Assert-MockCalled -CommandName 'Get-AzWebAppAccessRestrictionConfig' -Times 1 -Scope It
         }
@@ -31,15 +31,15 @@ Describe "Add-AppServiceIpException Unit Tests" -Tags @("Unit") {
         It "The specified Resource Config was updated, should not throw an error" {
             Mock Get-AzResource -MockWith { return @{
                     "ResourceGroupName" = $Config.resourceGroupName
-                    "Name"              = $Config.resourceName
+                    "Name"              = $Config.whitelistResourceName
                 }
             }
             Mock Get-AzWebAppAccessRestrictionConfig -MockWith { return @{
                 "MainSiteAccessRestrictions" = @("foo","bar")
-                } 
+                }
             }
             Mock Add-AzWebAppAccessRestrictionRule -MockWith { return $null }
-            { ./Add-AppServiceIpException -IpAddress $Config.ipAddress -ResourceName $Config.resourceName -RuleName $Config.ruleName } | Should Not throw
+            { ./Add-AppServiceIpException -IpAddress $Config.ipAddress -ResourceName $Config.whitelistResourceName -RuleName $Config.ruleName } | Should Not throw
             Assert-MockCalled -CommandName 'Get-AzResource' -Times 1 -Scope It
             Assert-MockCalled -CommandName 'Get-AzWebAppAccessRestrictionConfig' -Times 1 -Scope It
             Assert-MockCalled -CommandName 'Add-AzWebAppAccessRestrictionRule' -Times 1 -Scope It
@@ -50,12 +50,12 @@ Describe "Add-AppServiceIpException Unit Tests" -Tags @("Unit") {
         It "The specified Resource Config was identified to not have network restrictions, no whitelist required." {
             Mock Get-AzResource -MockWith { return @{
                     "ResourceGroupName" = $Config.resourceGroupName
-                    "Name"              = $Config.resourceName
+                    "Name"              = $Config.whitelistResourceName
                 }
             }
             Mock Get-AzWebAppAccessRestrictionConfig -MockWith { return $null }
             Mock Add-AzWebAppAccessRestrictionRule -MockWith { return $null }
-            { ./Add-AppServiceIpException -IpAddress $Config.ipAddress -ResourceName $Config.resourceName -RuleName $Config.ruleName } | Should Not throw
+            { ./Add-AppServiceIpException -IpAddress $Config.ipAddress -ResourceName $Config.whitelistResourceName -RuleName $Config.ruleName } | Should Not throw
             Assert-MockCalled -CommandName 'Get-AzResource' -Times 1 -Scope It
             Assert-MockCalled -CommandName 'Get-AzWebAppAccessRestrictionConfig' -Times 1 -Scope It
             Assert-MockCalled -CommandName 'Add-AzWebAppAccessRestrictionRule' -Times 0 -Scope It

--- a/Tests/UT.Remove-AppServiceIpException.Tests.ps1
+++ b/Tests/UT.Remove-AppServiceIpException.Tests.ps1
@@ -3,39 +3,74 @@ Set-Location $PSScriptRoot\..\Infrastructure-Scripts\
 
 Describe "Remove-AppServiceIpException Unit Tests" -Tags @("Unit") {
 
-    $Params = @{
+    $ParamsSingleAppService = @{
         IpAddress           = $Config.ipAddress
-        ResourceName        = $Config.resourceName
+        ResourceName        = $Config.whitelistResourceNameSingle
+    }
+    $ParamsMultipleAppServices = @{
+        IpAddress           = $Config.ipAddress
+        ResourceName        = $Config.whitelistResourceName
     }
 
     Context "Resource does not exist" {
         It "The specified Resource was not found in the subscription, throw an error" {
             Mock Get-AzResource -MockWith { return $null }
-            { ./Remove-AppServiceIpException @Params } | Should throw "Could not find a resource matching $($Config.resourceName) in the subscription"
+            { ./Remove-AppServiceIpException @ParamsMultipleAppServices } | Should throw "Could not find a resource matching $($Config.whitelistResourceName[0]) in the subscription"
             Assert-MockCalled -CommandName 'Get-AzResource' -Exactly 1 -Scope It
         }
     }
 
-    Context "Resources exists and app service ip exception doesn't exist" {
+    Context "Resources exist and app services ip exception doesn't exist" {
         It "Should output existing access restriction with given IP does not exist" {
 
             Mock Get-AzResource -MockWith {
                 return @{
                     "ResourceGroupName" = $Config.resourceGroupName
-                    "Name"              = $Config.resourceName
+                    "Name"              = $Config.whitelistResourceName
                 }
             }
             Mock Get-AzWebAppAccessRestrictionConfig -MockWith { return $null }
             Mock Write-Output -MockWith {}
-            { ./Remove-AppServiceIpException @Params } | Should Not throw
-            Assert-MockCalled -CommandName 'Get-AzResource' -Exactly 1 -Scope It
-            Assert-MockCalled -CommandName 'Get-AzWebAppAccessRestrictionConfig' -Exactly 1 -Scope It
-            Assert-MockCalled -CommandName 'Write-Output' -Exactly 1 -Scope It -ParameterFilter { $InputObject -eq " -> Could not find whitelisted $($Config.ipAddress) to remove on $($Config.resourceName)!" }
+            { ./Remove-AppServiceIpException @ParamsMultipleAppServices } | Should Not throw
+            Assert-MockCalled -CommandName 'Get-AzResource' -Exactly 2 -Scope It
+            Assert-MockCalled -CommandName 'Get-AzWebAppAccessRestrictionConfig' -Exactly 2 -Scope It
+            Assert-MockCalled -CommandName 'Write-Output' -Exactly 1 -Scope It -ParameterFilter { $InputObject -eq " -> Could not find whitelisted $($Config.ipAddress) to remove on $($Config.whitelistResourceName[0])!" }
+            Assert-MockCalled -CommandName 'Write-Output' -Exactly 1 -Scope It -ParameterFilter { $InputObject -eq " -> Could not find whitelisted $($Config.ipAddress) to remove on $($Config.whitelistResourceName[1])!" }
         }
     }
 
-    Context "Resource exists and app service ip access restriction rule exists" {
+    Context "Resources exist and app services ip access restriction rules exist" {
         It "Should remove the ip access restriction to the found resources" {
+
+            Mock Get-AzResource -MockWith {
+                return @{
+                    "ResourceGroupName" = $Config.resourceGroupName
+                    "Name"              = $Config.whitelistResourceName
+                }
+            }
+            Mock Get-AzWebAppAccessRestrictionConfig -MockWith {
+                return @{
+                    "MainSiteAccessRestrictions" = @{
+                        "IpAddress" = "$($Config.ipAddress)/32"
+                    }
+                }
+            }
+            Mock Remove-AzWebAppAccessRestrictionRule -MockWith { return $null }
+            Mock Write-Output -MockWith {}
+            { ./Remove-AppServiceIpException @ParamsMultipleAppServices } | Should Not throw
+            Assert-MockCalled -CommandName 'Get-AzResource' -Exactly 2 -Scope It
+            Assert-MockCalled -CommandName 'Get-AzWebAppAccessRestrictionConfig' -Exactly 2 -Scope It
+            Assert-MockCalled -CommandName 'Remove-AzWebAppAccessRestrictionRule' -Exactly 2 -Scope It
+            Assert-MockCalled -CommandName 'Write-Output' -Exactly 4 -Scope It
+            Assert-MockCalled -CommandName 'Write-Output' -Exactly 1 -Scope It -ParameterFilter { $InputObject -eq "  -> Removing $($Config.ipAddress) from $($Config.whitelistResourceName[0])" }
+            Assert-MockCalled -CommandName 'Write-Output' -Exactly 1 -Scope It -ParameterFilter { $InputObject -eq "  -> $($Config.ipAddress), removed from $($Config.whitelistResourceName[0])!" }
+            Assert-MockCalled -CommandName 'Write-Output' -Exactly 1 -Scope It -ParameterFilter { $InputObject -eq "  -> Removing $($Config.ipAddress) from $($Config.whitelistResourceName[1])" }
+            Assert-MockCalled -CommandName 'Write-Output' -Exactly 1 -Scope It -ParameterFilter { $InputObject -eq "  -> $($Config.ipAddress), removed from $($Config.whitelistResourceName[1])!" }
+        }
+    }
+
+    Context "Singular resource exists and app service ip access restriction rule exists" {
+        It "Should remove the ip access restriction to the found resource" {
 
             Mock Get-AzResource -MockWith {
                 return @{
@@ -52,13 +87,13 @@ Describe "Remove-AppServiceIpException Unit Tests" -Tags @("Unit") {
             }
             Mock Remove-AzWebAppAccessRestrictionRule -MockWith { return $null }
             Mock Write-Output -MockWith {}
-            { ./Remove-AppServiceIpException @Params } | Should Not throw
+            { ./Remove-AppServiceIpException @ParamsSingleAppService } | Should Not throw
             Assert-MockCalled -CommandName 'Get-AzResource' -Exactly 1 -Scope It
             Assert-MockCalled -CommandName 'Get-AzWebAppAccessRestrictionConfig' -Exactly 1 -Scope It
             Assert-MockCalled -CommandName 'Remove-AzWebAppAccessRestrictionRule' -Exactly 1 -Scope It
             Assert-MockCalled -CommandName 'Write-Output' -Exactly 2 -Scope It
-            Assert-MockCalled -CommandName 'Write-Output' -Exactly 1 -Scope It -ParameterFilter { $InputObject -eq "  -> Removing $($Config.ipAddress) from $($Config.resourceName)" }
-            Assert-MockCalled -CommandName 'Write-Output' -Exactly 1 -Scope It -ParameterFilter { $InputObject -eq "  -> $($Config.ipAddress), removed from $($Config.resourceName)!" }
+            Assert-MockCalled -CommandName 'Write-Output' -Exactly 1 -Scope It -ParameterFilter { $InputObject -eq "  -> Removing $($Config.ipAddress) from $($Config.whitelistResourceName[0])" }
+            Assert-MockCalled -CommandName 'Write-Output' -Exactly 1 -Scope It -ParameterFilter { $InputObject -eq "  -> $($Config.ipAddress), removed from $($Config.whitelistResourceName[0])!" }
         }
     }
 


### PR DESCRIPTION
Work for amending the whitelist script for an app service. This now allows the script to be used by a YAML task and to be used within environments that have no access restrictions in place.