### PR TITLE
DASD-13822 Added 'dev' to environment

### DIFF
--- a/Infrastructure-Scripts/Set-AppRoleAssignments/tools/Helpers.psm1
+++ b/Infrastructure-Scripts/Set-AppRoleAssignments/tools/Helpers.psm1
@@ -14,7 +14,7 @@ function Get-Environment {
         [String]$ResourceName
     )
 
-    $ValidEnvironments = @("at", "test", "test2", "demo", "pp", "prd", "mo")
+    $ValidEnvironments = @("dev", "at", "test", "test2", "demo", "pp", "prd", "mo")
     $Environment = $ResourceName.Split('-')[1]
 
     if ($Environment -in $ValidEnvironments) {

--- a/Tests/UT.Invoke-AfdContentPurge.Tests.ps1
+++ b/Tests/UT.Invoke-AfdContentPurge.Tests.ps1
@@ -20,7 +20,7 @@ Describe "Invoke-AfdContentPurge Unit Tests" -Tags @("Unit") {
     Context "Parameters are ok" {
         It "Should call Clear-AzFrontDoorCdnEndpointContent" {
             Mock Get-AzFrontDoorCdnEndpoint -MockWith {
-                $cdnEndpointExists = [Microsoft.Azure.PowerShell.Cmdlets.Cdn.Models.Api20240201.Endpoint]::new()
+                $cdnEndpointExists = [Microsoft.Azure.PowerShell.Cmdlets.Cdn.Models.Endpoint]::new()
                 return $cdnEndpointExists
             }
             Mock Clear-AzFrontDoorCdnEndpointContent -MockWith { Return $null }


### PR DESCRIPTION
As part of [FLP-1320: Fix System Acceptance Tests execution in the pipelineDev](https://skillsfundingagency.atlassian.net/browse/FLP-1320)
  [@Rohon Debray](https://ukgovernmentdfe.slack.com/team/U03BB5WU481) has been in conversation with Tom Gough (https://ukgovernmentdfe.slack.com/team/UDVDJ8WA3) regarding app role assignment for our automation tests.

Dev request:

Would it be possible for someone to look at developing some means by which we can grant app roles for automation tests, since there is no app service here for us to define this in the app role assignment config?