### PR TITLE
Change OutputVariable parameter to non-mandatory

### DIFF
--- a/Infrastructure-Scripts/Get-StorageAccountConnectionString.ps1
+++ b/Infrastructure-Scripts/Get-StorageAccountConnectionString.ps1
@@ -43,7 +43,7 @@ Param(
     [String]$StorageAccount,
     [Parameter(Mandatory = $false)]
     [switch]$UseSecondaryKey,
-    [Parameter(Mandatory = $true)]
+    [Parameter(Mandatory = $false)]
     [ValidateNotNullOrEmpty()]
     [String]$OutputVariable = "StorageConnectionString"
 )


### PR DESCRIPTION
Make OutputVariable optional with a default value to resolve ScriptAnalyzer rule violation (PSAvoidDefaultValueForMandatoryParameter)